### PR TITLE
Fully implement AWS4 signing support

### DIFF
--- a/autoscaling/autoscaling.go
+++ b/autoscaling/autoscaling.go
@@ -84,8 +84,9 @@ func (as *AutoScaling) query(params map[string]string, resp interface{}) error {
 		hreq.Header.Set("X-Amz-Security-Token", token)
 	}
 
-	signer := aws.NewV4Signer(as.Auth, "autoscaling", as.Region)
-	signer.Sign(hreq)
+	if err = aws.SignV4(hreq, as.Auth, "autoscaling", as.Region.Name); err != nil {
+		return err
+	}
 
 	if debug {
 		log.Printf("%v -> {\n", hreq)
@@ -104,7 +105,7 @@ func (as *AutoScaling) query(params map[string]string, resp interface{}) error {
 		log.Printf("response:\n")
 		log.Printf("%v\n}\n", string(dump))
 	}
-	if r.StatusCode != 200 {
+	if r.StatusCode != http.StatusOK {
 		return buildError(r)
 	}
 	err = xml.NewDecoder(r.Body).Decode(resp)

--- a/aws/export_test.go
+++ b/aws/export_test.go
@@ -12,7 +12,7 @@ func (s *V4Signer) RequestTime(req *http.Request) time.Time {
 	return s.requestTime(req)
 }
 
-func (s *V4Signer) CanonicalRequest(req *http.Request) string {
+func (s *V4Signer) CanonicalRequest(req *http.Request) (string, error) {
 	return s.canonicalRequest(req)
 }
 

--- a/aws/regions.go
+++ b/aws/regions.go
@@ -14,12 +14,13 @@ var USGovWest = Region{
 	"https://iam.us-gov.amazonaws.com",
 	"https://elasticloadbalancing.us-gov-west-1.amazonaws.com",
 	"https://dynamodb.us-gov-west-1.amazonaws.com",
-	ServiceInfo{"https://monitoring.us-gov-west-1.amazonaws.com", V2Signature},
+	"https://monitoring.us-gov-west-1.amazonaws.com",
 	"https://autoscaling.us-gov-west-1.amazonaws.com",
-	ServiceInfo{"https://rds.us-gov-west-1.amazonaws.com", V2Signature},
+	"https://rds.us-gov-west-1.amazonaws.com",
 	"https://sts.amazonaws.com",
 	"https://cloudformation.us-gov-west-1.amazonaws.com",
 	"https://ecs.us-gov-west-1.amazonaws.com",
+	SignV2,
 }
 
 var USEast = Region{
@@ -36,12 +37,13 @@ var USEast = Region{
 	"https://iam.amazonaws.com",
 	"https://elasticloadbalancing.us-east-1.amazonaws.com",
 	"https://dynamodb.us-east-1.amazonaws.com",
-	ServiceInfo{"https://monitoring.us-east-1.amazonaws.com", V2Signature},
+	"https://monitoring.us-east-1.amazonaws.com",
 	"https://autoscaling.us-east-1.amazonaws.com",
-	ServiceInfo{"https://rds.us-east-1.amazonaws.com", V2Signature},
+	"https://rds.us-east-1.amazonaws.com",
 	"https://sts.amazonaws.com",
 	"https://cloudformation.us-east-1.amazonaws.com",
 	"https://ecs.us-east-1.amazonaws.com",
+	SignV2,
 }
 
 var USWest = Region{
@@ -58,12 +60,13 @@ var USWest = Region{
 	"https://iam.amazonaws.com",
 	"https://elasticloadbalancing.us-west-1.amazonaws.com",
 	"https://dynamodb.us-west-1.amazonaws.com",
-	ServiceInfo{"https://monitoring.us-west-1.amazonaws.com", V2Signature},
+	"https://monitoring.us-west-1.amazonaws.com",
 	"https://autoscaling.us-west-1.amazonaws.com",
-	ServiceInfo{"https://rds.us-west-1.amazonaws.com", V2Signature},
+	"https://rds.us-west-1.amazonaws.com",
 	"https://sts.amazonaws.com",
 	"https://cloudformation.us-west-1.amazonaws.com",
 	"https://ecs.us-west-1.amazonaws.com",
+	SignV2,
 }
 
 var USWest2 = Region{
@@ -80,12 +83,13 @@ var USWest2 = Region{
 	"https://iam.amazonaws.com",
 	"https://elasticloadbalancing.us-west-2.amazonaws.com",
 	"https://dynamodb.us-west-2.amazonaws.com",
-	ServiceInfo{"https://monitoring.us-west-2.amazonaws.com", V2Signature},
+	"https://monitoring.us-west-2.amazonaws.com",
 	"https://autoscaling.us-west-2.amazonaws.com",
-	ServiceInfo{"https://rds.us-west-2.amazonaws.com", V2Signature},
+	"https://rds.us-west-2.amazonaws.com",
 	"https://sts.amazonaws.com",
 	"https://cloudformation.us-west-2.amazonaws.com",
 	"https://ecs.us-west-2.amazonaws.com",
+	SignV2,
 }
 
 var EUWest = Region{
@@ -102,18 +106,19 @@ var EUWest = Region{
 	"https://iam.amazonaws.com",
 	"https://elasticloadbalancing.eu-west-1.amazonaws.com",
 	"https://dynamodb.eu-west-1.amazonaws.com",
-	ServiceInfo{"https://monitoring.eu-west-1.amazonaws.com", V2Signature},
+	"https://monitoring.eu-west-1.amazonaws.com",
 	"https://autoscaling.eu-west-1.amazonaws.com",
-	ServiceInfo{"https://rds.eu-west-1.amazonaws.com", V2Signature},
+	"https://rds.eu-west-1.amazonaws.com",
 	"https://sts.amazonaws.com",
 	"https://cloudformation.eu-west-1.amazonaws.com",
 	"https://ecs.eu-west-1.amazonaws.com",
+	SignV2,
 }
 
 var EUCentral = Region{
 	"eu-central-1",
 	"https://ec2.eu-central-1.amazonaws.com",
-	"https://s3-eu-central-1.amazonaws.com",
+	"https://s3.eu-central-1.amazonaws.com", // s3.eu.. not s3-eu.. as thats what the SSL Cert matches
 	"",
 	true,
 	true,
@@ -124,12 +129,13 @@ var EUCentral = Region{
 	"https://iam.amazonaws.com",
 	"https://elasticloadbalancing.eu-central-1.amazonaws.com",
 	"https://dynamodb.eu-central-1.amazonaws.com",
-	ServiceInfo{"https://monitoring.eu-central-1.amazonaws.com", V2Signature},
+	"https://monitoring.eu-central-1.amazonaws.com",
 	"https://autoscaling.eu-central-1.amazonaws.com",
-	ServiceInfo{"https://rds.eu-central-1.amazonaws.com", V2Signature},
+	"https://rds.eu-central-1.amazonaws.com",
 	"https://sts.amazonaws.com",
 	"https://cloudformation.eu-central-1.amazonaws.com",
 	"https://ecs.eu-central-1.amazonaws.com",
+	SignV4Region("eu-central-1"),
 }
 
 var APSoutheast = Region{
@@ -146,12 +152,13 @@ var APSoutheast = Region{
 	"https://iam.amazonaws.com",
 	"https://elasticloadbalancing.ap-southeast-1.amazonaws.com",
 	"https://dynamodb.ap-southeast-1.amazonaws.com",
-	ServiceInfo{"https://monitoring.ap-southeast-1.amazonaws.com", V2Signature},
+	"https://monitoring.ap-southeast-1.amazonaws.com",
 	"https://autoscaling.ap-southeast-1.amazonaws.com",
-	ServiceInfo{"https://rds.ap-southeast-1.amazonaws.com", V2Signature},
+	"https://rds.ap-southeast-1.amazonaws.com",
 	"https://sts.amazonaws.com",
 	"https://cloudformation.ap-southeast-1.amazonaws.com",
 	"https://ecs.ap-southeast-1.amazonaws.com",
+	SignV2,
 }
 
 var APSoutheast2 = Region{
@@ -168,12 +175,13 @@ var APSoutheast2 = Region{
 	"https://iam.amazonaws.com",
 	"https://elasticloadbalancing.ap-southeast-2.amazonaws.com",
 	"https://dynamodb.ap-southeast-2.amazonaws.com",
-	ServiceInfo{"https://monitoring.ap-southeast-2.amazonaws.com", V2Signature},
+	"https://monitoring.ap-southeast-2.amazonaws.com",
 	"https://autoscaling.ap-southeast-2.amazonaws.com",
-	ServiceInfo{"https://rds.ap-southeast-2.amazonaws.com", V2Signature},
+	"https://rds.ap-southeast-2.amazonaws.com",
 	"https://sts.amazonaws.com",
 	"https://cloudformation.ap-southeast-2.amazonaws.com",
 	"https://ecs.ap-southeast-2.amazonaws.com",
+	SignV2,
 }
 
 var APNortheast = Region{
@@ -190,12 +198,13 @@ var APNortheast = Region{
 	"https://iam.amazonaws.com",
 	"https://elasticloadbalancing.ap-northeast-1.amazonaws.com",
 	"https://dynamodb.ap-northeast-1.amazonaws.com",
-	ServiceInfo{"https://monitoring.ap-northeast-1.amazonaws.com", V2Signature},
+	"https://monitoring.ap-northeast-1.amazonaws.com",
 	"https://autoscaling.ap-northeast-1.amazonaws.com",
-	ServiceInfo{"https://rds.ap-northeast-1.amazonaws.com", V2Signature},
+	"https://rds.ap-northeast-1.amazonaws.com",
 	"https://sts.amazonaws.com",
 	"https://cloudformation.ap-northeast-1.amazonaws.com",
 	"https://ecs.ap-northeast-1.amazonaws.com",
+	SignV2,
 }
 
 var SAEast = Region{
@@ -212,12 +221,13 @@ var SAEast = Region{
 	"https://iam.amazonaws.com",
 	"https://elasticloadbalancing.sa-east-1.amazonaws.com",
 	"https://dynamodb.sa-east-1.amazonaws.com",
-	ServiceInfo{"https://monitoring.sa-east-1.amazonaws.com", V2Signature},
+	"https://monitoring.sa-east-1.amazonaws.com",
 	"https://autoscaling.sa-east-1.amazonaws.com",
-	ServiceInfo{"https://rds.sa-east-1.amazonaws.com", V2Signature},
+	"https://rds.sa-east-1.amazonaws.com",
 	"https://sts.amazonaws.com",
 	"https://cloudformation.sa-east-1.amazonaws.com",
 	"https://ecs.sa-east-1.amazonaws.com",
+	SignV4Region("sa-east-1"),
 }
 
 var CNNorth = Region{
@@ -234,10 +244,11 @@ var CNNorth = Region{
 	"https://iam.cn-north-1.amazonaws.com.cn",
 	"https://elasticloadbalancing.cn-north-1.amazonaws.com.cn",
 	"https://dynamodb.cn-north-1.amazonaws.com.cn",
-	ServiceInfo{"https://monitoring.cn-north-1.amazonaws.com.cn", V4Signature},
+	"https://monitoring.cn-north-1.amazonaws.com.cn",
 	"https://autoscaling.cn-north-1.amazonaws.com.cn",
-	ServiceInfo{"https://rds.cn-north-1.amazonaws.com.cn", V4Signature},
+	"https://rds.cn-north-1.amazonaws.com.cn",
 	"https://sts.cn-north-1.amazonaws.com.cn",
 	"https://cloudformation.cn-north-1.amazonaws.com.cn",
 	"https://ecs.cn-north-1.amazonaws.com.cn",
+	SignV4Region("cn-north-1"),
 }

--- a/aws/sign.go
+++ b/aws/sign.go
@@ -15,28 +15,35 @@ import (
 	"time"
 )
 
+// SignerFunc represents a function that can sign a http.Request with the given Auth details.
+type SignerFunc func(*http.Request, Auth, string) error
+
 type V2Signer struct {
-	auth    Auth
-	service ServiceInfo
-	host    string
+	auth     Auth
+	endpoint string
 }
 
 var b64 = base64.StdEncoding
 
-func NewV2Signer(auth Auth, service ServiceInfo) (*V2Signer, error) {
-	u, err := url.Parse(service.Endpoint)
-	if err != nil {
-		return nil, err
-	}
-	return &V2Signer{auth: auth, service: service, host: u.Host}, nil
+func NewV2Signer(auth Auth, endpoint string) (*V2Signer, error) {
+	return &V2Signer{auth: auth, endpoint: endpoint}, nil
 }
 
 func (s *V2Signer) Sign(method, path string, params map[string]string) {
-	params["AWSAccessKeyId"] = s.auth.AccessKey
-	params["SignatureVersion"] = "2"
-	params["SignatureMethod"] = "HmacSHA256"
-	if s.auth.Token() != "" {
-		params["SecurityToken"] = s.auth.Token()
+	req, _ := NewRequest(s.endpoint, method, path, params)
+	SignV2(req, s.auth, "") // service is not used so just set blank
+}
+
+// SignV2 signs req using the AWS version 2 signature with the given credentials.
+// serviceName is present to so that it can be used as a SignerFunc and is not used
+func SignV2(req *http.Request, auth Auth, serviceName string) (err error) {
+	vals := req.URL.Query()
+
+	vals.Set("AWSAccessKeyId", auth.AccessKey)
+	vals.Set("SignatureVersion", "2")
+	vals.Set("SignatureMethod", "HmacSHA256")
+	if auth.Token() != "" {
+		vals.Set("SecurityToken", auth.Token())
 	}
 
 	// AWS specifies that the parameters in a signed request must
@@ -44,21 +51,31 @@ func (s *V2Signer) Sign(method, path string, params map[string]string) {
 	// from the natural order of the encoded value of key=value.
 	// Percent and Equals affect the sorting order.
 	var keys, sarray []string
-	for k, _ := range params {
+	for k, _ := range vals {
 		keys = append(keys, k)
 	}
 	sort.Strings(keys)
 	for _, k := range keys {
-		sarray = append(sarray, Encode(k)+"="+Encode(params[k]))
+		sarray = append(sarray, Encode(k)+"="+Encode(vals.Get(k)))
 	}
+
+	path := req.URL.Path
+	if path == "" {
+		path = "/"
+	}
+
 	joined := strings.Join(sarray, "&")
-	payload := method + "\n" + s.host + "\n" + path + "\n" + joined
-	hash := hmac.New(sha256.New, []byte(s.auth.SecretKey))
+	payload := req.Method + "\n" + req.Host + "\n" + path + "\n" + joined
+	hash := hmac.New(sha256.New, []byte(auth.SecretKey))
 	hash.Write([]byte(payload))
 	signature := make([]byte, b64.EncodedLen(hash.Size()))
 	b64.Encode(signature, hash.Sum(nil))
 
-	params["Signature"] = string(signature)
+	vals.Set("Signature", string(signature))
+
+	req.URL.RawQuery = vals.Encode()
+
+	return nil
 }
 
 // Common date formats for signing requests
@@ -75,39 +92,43 @@ func NewRoute53Signer(auth Auth) *Route53Signer {
 	return &Route53Signer{auth: auth}
 }
 
-// getCurrentDate fetches the date stamp from the aws servers to
-// ensure the auth headers are within 5 minutes of the server time
-func (s *Route53Signer) getCurrentDate() string {
-	response, err := http.Get("https://route53.amazonaws.com/date")
-	if err != nil {
-		fmt.Print("Unable to get date from amazon: ", err)
-		return ""
-	}
-
-	response.Body.Close()
-	return response.Header.Get("Date")
-}
-
 // Creates the authorize signature based on the date stamp and secret key
-func (s *Route53Signer) getHeaderAuthorize(message string) string {
-	hmacSha256 := hmac.New(sha256.New, []byte(s.auth.SecretKey))
-	hmacSha256.Write([]byte(message))
-	cryptedString := hmacSha256.Sum(nil)
+func getHeaderAuthorize(date string, auth Auth) string {
+	hmacSha256 := hmac.New(sha256.New, []byte(auth.SecretKey))
+	hmacSha256.Write([]byte(date))
 
-	return base64.StdEncoding.EncodeToString(cryptedString)
+	return base64.StdEncoding.EncodeToString(hmacSha256.Sum(nil))
 }
 
 // Adds all the required headers for AWS Route53 API to the request
 // including the authorization
 func (s *Route53Signer) Sign(req *http.Request) {
-	date := s.getCurrentDate()
-	authHeader := fmt.Sprintf("AWS3-HTTPS AWSAccessKeyId=%s,Algorithm=%s,Signature=%s",
-		s.auth.AccessKey, "HmacSHA256", s.getHeaderAuthorize(date))
-
 	req.Header.Set("Host", req.Host)
+	req.Header.Set("Content-Type", "application/xml")
+	SignRoute53(req, s.auth, "")
+}
+
+// SignRoute53 signs req using the AWS Route53 signature with the given credentials.
+// In contrast to Route53Signer.Sign this only sets the X-Amzn-Authorization and X-Amz-Date headers.
+// serviceName is present to so that it can be used as a SignerFunc and is not used
+func SignRoute53(req *http.Request, auth Auth, serviceName string) error {
+	resp, err := http.Get("https://route53.amazonaws.com/date")
+	if resp != nil {
+		resp.Body.Close()
+	}
+
+	if err != nil {
+		return err
+	}
+
+	date := resp.Header.Get("Date")
+	authHeader := fmt.Sprintf("AWS3-HTTPS AWSAccessKeyId=%s,Algorithm=%s,Signature=%s",
+		auth.AccessKey, "HmacSHA256", getHeaderAuthorize(date, auth))
+
 	req.Header.Set("X-Amzn-Authorization", authHeader)
 	req.Header.Set("X-Amz-Date", date)
-	req.Header.Set("Content-Type", "application/xml")
+
+	return nil
 }
 
 /*
@@ -117,14 +138,26 @@ Signature Version 4 Signing Process. (http://goo.gl/u1OWZz)
 type V4Signer struct {
 	auth        Auth
 	serviceName string
-	region      Region
+	regionName  string
+}
+
+// SignV4Region is an adapter to allow Signer to be used with SignV4 given a regionName.
+func SignV4Region(regionName string) SignerFunc {
+	return func(req *http.Request, auth Auth, serviceName string) error {
+		return SignV4(req, auth, serviceName, regionName)
+	}
+}
+
+// SignV4 signs the req with auth for regionName
+func SignV4(req *http.Request, auth Auth, serviceName, regionName string) error {
+	return NewV4Signer(auth, serviceName, regionName).Sign(req)
 }
 
 /*
 Return a new instance of a V4Signer capable of signing AWS requests.
 */
-func NewV4Signer(auth Auth, serviceName string, region Region) *V4Signer {
-	return &V4Signer{auth: auth, serviceName: serviceName, region: region}
+func NewV4Signer(auth Auth, serviceName, regionName string) *V4Signer {
+	return &V4Signer{auth: auth, serviceName: serviceName, regionName: regionName}
 }
 
 /*
@@ -132,22 +165,25 @@ Sign a request according to the AWS Signature Version 4 Signing Process. (http:/
 
 The signed request will include an "x-amz-date" header with a current timestamp if a valid "x-amz-date"
 or "date" header was not available in the original request. In addition, AWS Signature Version 4 requires
-the "host" header to be a signed header, therefor the Sign method will manually set a "host" header from
+the "host" header to be a signed header, therefore the Sign method will manually set a "host" header from
 the request.Host.
 
 The signed request will include a new "Authorization" header indicating that the request has been signed.
 
 Any changes to the request after signing the request will invalidate the signature.
 */
-func (s *V4Signer) Sign(req *http.Request) {
-	req.Header.Set("host", req.Host)                  // host header must be included as a signed header
-	t := s.requestTime(req)                           // Get requst time
-	creq := s.canonicalRequest(req)                   // Build canonical request
+func (s *V4Signer) Sign(req *http.Request) error {
+	req.Header.Set("Host", req.Host)     // host header must be included as a signed header
+	t := s.requestTime(req)              // Get requst time
+	creq, err := s.canonicalRequest(req) // Build canonical request
+	if err != nil {
+		return err
+	}
 	sts := s.stringToSign(t, creq)                    // Build string to sign
 	signature := s.signature(t, sts)                  // Calculate the AWS Signature Version 4
 	auth := s.authorization(req.Header, t, signature) // Create Authorization header value
 	req.Header.Set("Authorization", auth)             // Add Authorization header to request
-	return
+	return nil
 }
 
 /*
@@ -200,15 +236,22 @@ canonicalRequest method creates the canonical request according to Task 1 of the
       SignedHeaders + '\n' +
       HexEncode(Hash(Payload))
 */
-func (s *V4Signer) canonicalRequest(req *http.Request) string {
+func (s *V4Signer) canonicalRequest(req *http.Request) (string, error) {
 	c := new(bytes.Buffer)
+
+	// Precalculate hash as it can add a header needed by canonicalHeaders
+	hash, err := s.payloadHash(req)
+	if err != nil {
+		return "", err
+	}
+
 	fmt.Fprintf(c, "%s\n", req.Method)
 	fmt.Fprintf(c, "%s\n", s.canonicalURI(req.URL))
 	fmt.Fprintf(c, "%s\n", s.canonicalQueryString(req.URL))
 	fmt.Fprintf(c, "%s\n\n", s.canonicalHeaders(req.Header))
 	fmt.Fprintf(c, "%s\n", s.signedHeaders(req.Header))
-	fmt.Fprintf(c, "%s", s.payloadHash(req))
-	return c.String()
+	fmt.Fprintf(c, "%s", hash)
+	return c.String(), nil
 }
 
 func (s *V4Signer) canonicalURI(u *url.URL) string {
@@ -265,20 +308,32 @@ func (s *V4Signer) signedHeaders(h http.Header) string {
 	return strings.Join(a, ";")
 }
 
-func (s *V4Signer) payloadHash(req *http.Request) string {
-	var b []byte
-	if req.Body == nil {
-		b = []byte("")
-	} else {
-		var err error
-		b, err = ioutil.ReadAll(req.Body)
-		if err != nil {
-			// TODO: I REALLY DON'T LIKE THIS PANIC!!!!
-			panic(err)
+// payloadHash returns the payload hash for the req.
+// This will return the value of X-Amz-Content-Sha256 if present otherwise
+// it will be calculated from the req details and the X-Amz-Content-Sha256 set.
+//
+// Due to the fact this can add a new header it must be called before any call
+// to canonicalHeaders, otherwise the canonicalHeaders will be missing the added
+// header.
+func (s *V4Signer) payloadHash(req *http.Request) (string, error) {
+	hash := req.Header.Get("X-Amz-Content-Sha256")
+	if hash == "" {
+		var b []byte
+		if req.Body == nil {
+			b = []byte("")
+		} else {
+			var err error
+			b, err = ioutil.ReadAll(req.Body)
+			if err != nil {
+				return "", err
+			}
 		}
+		req.Body = ioutil.NopCloser(bytes.NewBuffer(b))
+		hash = s.hash(string(b))
+		req.Header.Add("X-Amz-Content-Sha256", hash)
 	}
-	req.Body = ioutil.NopCloser(bytes.NewBuffer(b))
-	return s.hash(string(b))
+
+	return hash, nil
 }
 
 /*
@@ -300,7 +355,7 @@ func (s *V4Signer) stringToSign(t time.Time, creq string) string {
 }
 
 func (s *V4Signer) credentialScope(t time.Time) string {
-	return fmt.Sprintf("%s/%s/%s/aws4_request", t.Format(ISO8601BasicFormatShort), s.region.Name, s.serviceName)
+	return fmt.Sprintf("%s/%s/%s/aws4_request", t.Format(ISO8601BasicFormatShort), s.regionName, s.serviceName)
 }
 
 /*
@@ -324,7 +379,7 @@ derivedKey method derives a signing key to be used for signing a request.
 */
 func (s *V4Signer) derivedKey(t time.Time) []byte {
 	h := s.hmac([]byte("AWS4"+s.auth.SecretKey), []byte(t.Format(ISO8601BasicFormatShort)))
-	h = s.hmac(h, []byte(s.region.Name))
+	h = s.hmac(h, []byte(s.regionName))
 	h = s.hmac(h, []byte(s.serviceName))
 	h = s.hmac(h, []byte("aws4_request"))
 	return h

--- a/aws/sign_test.go
+++ b/aws/sign_test.go
@@ -51,10 +51,10 @@ func (s *V4SignerSuite) SetUpSuite(c *C) {
 				url:     "/",
 				headers: []string{"DATE:Mon, 09 Sep 2011 23:36:00 GMT", "ZOO:zoobar", "zoo:foobar", "zoo:zoobar"},
 			},
-			canonicalRequest: "POST\n/\n\ndate:Mon, 09 Sep 2011 23:36:00 GMT\nhost:host.foo.com\nzoo:foobar,zoobar,zoobar\n\ndate;host;zoo\ne3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-			stringToSign:     "AWS4-HMAC-SHA256\n20110909T233600Z\n20110909/us-east-1/host/aws4_request\n3c52f0eaae2b61329c0a332e3fa15842a37bc5812cf4d80eb64784308850e313",
-			signature:        "54afcaaf45b331f81cd2edb974f7b824ff4dd594cbbaa945ed636b48477368ed",
-			authorization:    "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20110909/us-east-1/host/aws4_request, SignedHeaders=date;host;zoo, Signature=54afcaaf45b331f81cd2edb974f7b824ff4dd594cbbaa945ed636b48477368ed",
+			canonicalRequest: "POST\n/\n\ndate:Mon, 09 Sep 2011 23:36:00 GMT\nhost:host.foo.com\nx-amz-content-sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855\nzoo:foobar,zoobar,zoobar\n\ndate;host;x-amz-content-sha256;zoo\ne3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+			stringToSign:     "AWS4-HMAC-SHA256\n20110909T233600Z\n20110909/us-east-1/host/aws4_request\nb47a355a1f4aed01ddaae2a0992cf11758413038797b8768c7668c04292994f0",
+			signature:        "b48d915443fc61838f63037d445e630c55e7d36efa07ce417e28313b06162bb2",
+			authorization:    "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20110909/us-east-1/host/aws4_request, SignedHeaders=date;host;x-amz-content-sha256;zoo, Signature=b48d915443fc61838f63037d445e630c55e7d36efa07ce417e28313b06162bb2",
 		},
 
 		// get-header-value-order
@@ -66,10 +66,10 @@ func (s *V4SignerSuite) SetUpSuite(c *C) {
 				url:     "/",
 				headers: []string{"DATE:Mon, 09 Sep 2011 23:36:00 GMT", "p:z", "p:a", "p:p", "p:a"},
 			},
-			canonicalRequest: "POST\n/\n\ndate:Mon, 09 Sep 2011 23:36:00 GMT\nhost:host.foo.com\np:a,a,p,z\n\ndate;host;p\ne3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-			stringToSign:     "AWS4-HMAC-SHA256\n20110909T233600Z\n20110909/us-east-1/host/aws4_request\n94c0389fefe0988cbbedc8606f0ca0b485b48da010d09fc844b45b697c8924fe",
-			signature:        "d2973954263943b11624a11d1c963ca81fb274169c7868b2858c04f083199e3d",
-			authorization:    "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20110909/us-east-1/host/aws4_request, SignedHeaders=date;host;p, Signature=d2973954263943b11624a11d1c963ca81fb274169c7868b2858c04f083199e3d",
+			canonicalRequest: "POST\n/\n\ndate:Mon, 09 Sep 2011 23:36:00 GMT\nhost:host.foo.com\np:a,a,p,z\nx-amz-content-sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855\n\ndate;host;p;x-amz-content-sha256\ne3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+			stringToSign:     "AWS4-HMAC-SHA256\n20110909T233600Z\n20110909/us-east-1/host/aws4_request\n76823ce9cd3e250ee87dbc7142653ecabf6d80a9a91f3199dc7c2ed22eeb668b",
+			signature:        "0a5450064fe28a63773c01290500cc67b2e52ffb8efd29af6d15df191e313e8b",
+			authorization:    "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20110909/us-east-1/host/aws4_request, SignedHeaders=date;host;p;x-amz-content-sha256, Signature=0a5450064fe28a63773c01290500cc67b2e52ffb8efd29af6d15df191e313e8b",
 		},
 
 		// get-header-value-trim
@@ -81,10 +81,10 @@ func (s *V4SignerSuite) SetUpSuite(c *C) {
 				url:     "/",
 				headers: []string{"DATE:Mon, 09 Sep 2011 23:36:00 GMT", "p: phfft "},
 			},
-			canonicalRequest: "POST\n/\n\ndate:Mon, 09 Sep 2011 23:36:00 GMT\nhost:host.foo.com\np:phfft\n\ndate;host;p\ne3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-			stringToSign:     "AWS4-HMAC-SHA256\n20110909T233600Z\n20110909/us-east-1/host/aws4_request\ndddd1902add08da1ac94782b05f9278c08dc7468db178a84f8950d93b30b1f35",
-			signature:        "debf546796015d6f6ded8626f5ce98597c33b47b9164cf6b17b4642036fcb592",
-			authorization:    "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20110909/us-east-1/host/aws4_request, SignedHeaders=date;host;p, Signature=debf546796015d6f6ded8626f5ce98597c33b47b9164cf6b17b4642036fcb592",
+			canonicalRequest: "POST\n/\n\ndate:Mon, 09 Sep 2011 23:36:00 GMT\nhost:host.foo.com\np:phfft\nx-amz-content-sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855\n\ndate;host;p;x-amz-content-sha256\ne3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+			stringToSign:     "AWS4-HMAC-SHA256\n20110909T233600Z\n20110909/us-east-1/host/aws4_request\n5fc8bd66e043705a5414321c921183106f96b3ab394b106383ea62f7de105cb5",
+			signature:        "c7876fcc7fa5fdfd0d087d47c110c945d1bd1528828507b9c2c7cff6f3e8d838",
+			authorization:    "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20110909/us-east-1/host/aws4_request, SignedHeaders=date;host;p;x-amz-content-sha256, Signature=c7876fcc7fa5fdfd0d087d47c110c945d1bd1528828507b9c2c7cff6f3e8d838",
 		},
 
 		// get-relative-relative
@@ -96,10 +96,10 @@ func (s *V4SignerSuite) SetUpSuite(c *C) {
 				url:     "/foo/bar/../..",
 				headers: []string{"Date:Mon, 09 Sep 2011 23:36:00 GMT"},
 			},
-			canonicalRequest: "GET\n/\n\ndate:Mon, 09 Sep 2011 23:36:00 GMT\nhost:host.foo.com\n\ndate;host\ne3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-			stringToSign:     "AWS4-HMAC-SHA256\n20110909T233600Z\n20110909/us-east-1/host/aws4_request\n366b91fb121d72a00f46bbe8d395f53a102b06dfb7e79636515208ed3fa606b1",
-			signature:        "b27ccfbfa7df52a200ff74193ca6e32d4b48b8856fab7ebf1c595d0670a7e470",
-			authorization:    "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20110909/us-east-1/host/aws4_request, SignedHeaders=date;host, Signature=b27ccfbfa7df52a200ff74193ca6e32d4b48b8856fab7ebf1c595d0670a7e470",
+			canonicalRequest: "GET\n/\n\ndate:Mon, 09 Sep 2011 23:36:00 GMT\nhost:host.foo.com\nx-amz-content-sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855\n\ndate;host;x-amz-content-sha256\ne3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+			stringToSign:     "AWS4-HMAC-SHA256\n20110909T233600Z\n20110909/us-east-1/host/aws4_request\nedf3a954ef9b74cf366ad17b25bc502050eb85bcd3d86b24431cb9aea8761c84",
+			signature:        "6ad5d9fd6d93c5855f08c4675163da70623fcca6f49f9c96a3890c1c32877a2e",
+			authorization:    "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20110909/us-east-1/host/aws4_request, SignedHeaders=date;host;x-amz-content-sha256, Signature=6ad5d9fd6d93c5855f08c4675163da70623fcca6f49f9c96a3890c1c32877a2e",
 		},
 
 		// get-relative
@@ -111,10 +111,10 @@ func (s *V4SignerSuite) SetUpSuite(c *C) {
 				url:     "/foo/..",
 				headers: []string{"Date:Mon, 09 Sep 2011 23:36:00 GMT"},
 			},
-			canonicalRequest: "GET\n/\n\ndate:Mon, 09 Sep 2011 23:36:00 GMT\nhost:host.foo.com\n\ndate;host\ne3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-			stringToSign:     "AWS4-HMAC-SHA256\n20110909T233600Z\n20110909/us-east-1/host/aws4_request\n366b91fb121d72a00f46bbe8d395f53a102b06dfb7e79636515208ed3fa606b1",
-			signature:        "b27ccfbfa7df52a200ff74193ca6e32d4b48b8856fab7ebf1c595d0670a7e470",
-			authorization:    "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20110909/us-east-1/host/aws4_request, SignedHeaders=date;host, Signature=b27ccfbfa7df52a200ff74193ca6e32d4b48b8856fab7ebf1c595d0670a7e470",
+			canonicalRequest: "GET\n/\n\ndate:Mon, 09 Sep 2011 23:36:00 GMT\nhost:host.foo.com\nx-amz-content-sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855\n\ndate;host;x-amz-content-sha256\ne3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+			stringToSign:     "AWS4-HMAC-SHA256\n20110909T233600Z\n20110909/us-east-1/host/aws4_request\nedf3a954ef9b74cf366ad17b25bc502050eb85bcd3d86b24431cb9aea8761c84",
+			signature:        "6ad5d9fd6d93c5855f08c4675163da70623fcca6f49f9c96a3890c1c32877a2e",
+			authorization:    "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20110909/us-east-1/host/aws4_request, SignedHeaders=date;host;x-amz-content-sha256, Signature=6ad5d9fd6d93c5855f08c4675163da70623fcca6f49f9c96a3890c1c32877a2e",
 		},
 
 		// get-slash-dot-slash
@@ -126,10 +126,10 @@ func (s *V4SignerSuite) SetUpSuite(c *C) {
 				url:     "/./",
 				headers: []string{"Date:Mon, 09 Sep 2011 23:36:00 GMT"},
 			},
-			canonicalRequest: "GET\n/\n\ndate:Mon, 09 Sep 2011 23:36:00 GMT\nhost:host.foo.com\n\ndate;host\ne3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-			stringToSign:     "AWS4-HMAC-SHA256\n20110909T233600Z\n20110909/us-east-1/host/aws4_request\n366b91fb121d72a00f46bbe8d395f53a102b06dfb7e79636515208ed3fa606b1",
-			signature:        "b27ccfbfa7df52a200ff74193ca6e32d4b48b8856fab7ebf1c595d0670a7e470",
-			authorization:    "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20110909/us-east-1/host/aws4_request, SignedHeaders=date;host, Signature=b27ccfbfa7df52a200ff74193ca6e32d4b48b8856fab7ebf1c595d0670a7e470",
+			canonicalRequest: "GET\n/\n\ndate:Mon, 09 Sep 2011 23:36:00 GMT\nhost:host.foo.com\nx-amz-content-sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855\n\ndate;host;x-amz-content-sha256\ne3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+			stringToSign:     "AWS4-HMAC-SHA256\n20110909T233600Z\n20110909/us-east-1/host/aws4_request\nedf3a954ef9b74cf366ad17b25bc502050eb85bcd3d86b24431cb9aea8761c84",
+			signature:        "6ad5d9fd6d93c5855f08c4675163da70623fcca6f49f9c96a3890c1c32877a2e",
+			authorization:    "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20110909/us-east-1/host/aws4_request, SignedHeaders=date;host;x-amz-content-sha256, Signature=6ad5d9fd6d93c5855f08c4675163da70623fcca6f49f9c96a3890c1c32877a2e",
 		},
 
 		// get-slash-pointless-dot
@@ -141,10 +141,10 @@ func (s *V4SignerSuite) SetUpSuite(c *C) {
 				url:     "/./foo",
 				headers: []string{"Date:Mon, 09 Sep 2011 23:36:00 GMT"},
 			},
-			canonicalRequest: "GET\n/foo\n\ndate:Mon, 09 Sep 2011 23:36:00 GMT\nhost:host.foo.com\n\ndate;host\ne3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-			stringToSign:     "AWS4-HMAC-SHA256\n20110909T233600Z\n20110909/us-east-1/host/aws4_request\n8021a97572ee460f87ca67f4e8c0db763216d84715f5424a843a5312a3321e2d",
-			signature:        "910e4d6c9abafaf87898e1eb4c929135782ea25bb0279703146455745391e63a",
-			authorization:    "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20110909/us-east-1/host/aws4_request, SignedHeaders=date;host, Signature=910e4d6c9abafaf87898e1eb4c929135782ea25bb0279703146455745391e63a",
+			canonicalRequest: "GET\n/foo\n\ndate:Mon, 09 Sep 2011 23:36:00 GMT\nhost:host.foo.com\nx-amz-content-sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855\n\ndate;host;x-amz-content-sha256\ne3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+			stringToSign:     "AWS4-HMAC-SHA256\n20110909T233600Z\n20110909/us-east-1/host/aws4_request\nc0dd19b115fdcd7b17e21b9845d31c5caead32a194b4dd2d720280770c182db3",
+			signature:        "b79af6d6802186bdd3c7a22ec726b88ee0ff8bd15cb3ae7fa81d3e1decf2a3f2",
+			authorization:    "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20110909/us-east-1/host/aws4_request, SignedHeaders=date;host;x-amz-content-sha256, Signature=b79af6d6802186bdd3c7a22ec726b88ee0ff8bd15cb3ae7fa81d3e1decf2a3f2",
 		},
 
 		// get-slash
@@ -156,10 +156,10 @@ func (s *V4SignerSuite) SetUpSuite(c *C) {
 				url:     "//",
 				headers: []string{"Date:Mon, 09 Sep 2011 23:36:00 GMT"},
 			},
-			canonicalRequest: "GET\n/\n\ndate:Mon, 09 Sep 2011 23:36:00 GMT\nhost:host.foo.com\n\ndate;host\ne3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-			stringToSign:     "AWS4-HMAC-SHA256\n20110909T233600Z\n20110909/us-east-1/host/aws4_request\n366b91fb121d72a00f46bbe8d395f53a102b06dfb7e79636515208ed3fa606b1",
-			signature:        "b27ccfbfa7df52a200ff74193ca6e32d4b48b8856fab7ebf1c595d0670a7e470",
-			authorization:    "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20110909/us-east-1/host/aws4_request, SignedHeaders=date;host, Signature=b27ccfbfa7df52a200ff74193ca6e32d4b48b8856fab7ebf1c595d0670a7e470",
+			canonicalRequest: "GET\n/\n\ndate:Mon, 09 Sep 2011 23:36:00 GMT\nhost:host.foo.com\nx-amz-content-sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855\n\ndate;host;x-amz-content-sha256\ne3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+			stringToSign:     "AWS4-HMAC-SHA256\n20110909T233600Z\n20110909/us-east-1/host/aws4_request\nedf3a954ef9b74cf366ad17b25bc502050eb85bcd3d86b24431cb9aea8761c84",
+			signature:        "6ad5d9fd6d93c5855f08c4675163da70623fcca6f49f9c96a3890c1c32877a2e",
+			authorization:    "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20110909/us-east-1/host/aws4_request, SignedHeaders=date;host;x-amz-content-sha256, Signature=6ad5d9fd6d93c5855f08c4675163da70623fcca6f49f9c96a3890c1c32877a2e",
 		},
 
 		// get-slashes
@@ -171,10 +171,10 @@ func (s *V4SignerSuite) SetUpSuite(c *C) {
 				url:     "//foo//",
 				headers: []string{"Date:Mon, 09 Sep 2011 23:36:00 GMT"},
 			},
-			canonicalRequest: "GET\n/foo/\n\ndate:Mon, 09 Sep 2011 23:36:00 GMT\nhost:host.foo.com\n\ndate;host\ne3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-			stringToSign:     "AWS4-HMAC-SHA256\n20110909T233600Z\n20110909/us-east-1/host/aws4_request\n6bb4476ee8745730c9cb79f33a0c70baa6d8af29c0077fa12e4e8f1dd17e7098",
-			signature:        "b00392262853cfe3201e47ccf945601079e9b8a7f51ee4c3d9ee4f187aa9bf19",
-			authorization:    "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20110909/us-east-1/host/aws4_request, SignedHeaders=date;host, Signature=b00392262853cfe3201e47ccf945601079e9b8a7f51ee4c3d9ee4f187aa9bf19",
+			canonicalRequest: "GET\n/foo/\n\ndate:Mon, 09 Sep 2011 23:36:00 GMT\nhost:host.foo.com\nx-amz-content-sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855\n\ndate;host;x-amz-content-sha256\ne3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+			stringToSign:     "AWS4-HMAC-SHA256\n20110909T233600Z\n20110909/us-east-1/host/aws4_request\n4a7592c23ce09aa58e45d8cb1dc827287cdcf621e98e784f3d86715bb4c4e24e",
+			signature:        "cac8d6fc96a93d075848795a33138fa0dfb81a9b9a1387486b67c5803659107b",
+			authorization:    "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20110909/us-east-1/host/aws4_request, SignedHeaders=date;host;x-amz-content-sha256, Signature=cac8d6fc96a93d075848795a33138fa0dfb81a9b9a1387486b67c5803659107b",
 		},
 
 		// get-space
@@ -186,10 +186,10 @@ func (s *V4SignerSuite) SetUpSuite(c *C) {
 				url:     "/%20/foo",
 				headers: []string{"Date:Mon, 09 Sep 2011 23:36:00 GMT"},
 			},
-			canonicalRequest: "GET\n/%20/foo\n\ndate:Mon, 09 Sep 2011 23:36:00 GMT\nhost:host.foo.com\n\ndate;host\ne3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-			stringToSign:     "AWS4-HMAC-SHA256\n20110909T233600Z\n20110909/us-east-1/host/aws4_request\n69c45fb9fe3fd76442b5086e50b2e9fec8298358da957b293ef26e506fdfb54b",
-			signature:        "f309cfbd10197a230c42dd17dbf5cca8a0722564cb40a872d25623cfa758e374",
-			authorization:    "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20110909/us-east-1/host/aws4_request, SignedHeaders=date;host, Signature=f309cfbd10197a230c42dd17dbf5cca8a0722564cb40a872d25623cfa758e374",
+			canonicalRequest: "GET\n/%20/foo\n\ndate:Mon, 09 Sep 2011 23:36:00 GMT\nhost:host.foo.com\nx-amz-content-sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855\n\ndate;host;x-amz-content-sha256\ne3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+			stringToSign:     "AWS4-HMAC-SHA256\n20110909T233600Z\n20110909/us-east-1/host/aws4_request\nf8efe2a424f379ce780bcf0b1bbd93a2377fac1cd9b34283473c5d287fb98daa",
+			signature:        "280de7094bfa4f41dee69c9af17de9c4652699c284495c6769426170fe9b0407",
+			authorization:    "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20110909/us-east-1/host/aws4_request, SignedHeaders=date;host;x-amz-content-sha256, Signature=280de7094bfa4f41dee69c9af17de9c4652699c284495c6769426170fe9b0407",
 		},
 
 		// get-unreserved
@@ -201,10 +201,10 @@ func (s *V4SignerSuite) SetUpSuite(c *C) {
 				url:     "/-._~0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz",
 				headers: []string{"Date:Mon, 09 Sep 2011 23:36:00 GMT"},
 			},
-			canonicalRequest: "GET\n/-._~0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz\n\ndate:Mon, 09 Sep 2011 23:36:00 GMT\nhost:host.foo.com\n\ndate;host\ne3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-			stringToSign:     "AWS4-HMAC-SHA256\n20110909T233600Z\n20110909/us-east-1/host/aws4_request\ndf63ee3247c0356c696a3b21f8d8490b01fa9cd5bc6550ef5ef5f4636b7b8901",
-			signature:        "830cc36d03f0f84e6ee4953fbe701c1c8b71a0372c63af9255aa364dd183281e",
-			authorization:    "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20110909/us-east-1/host/aws4_request, SignedHeaders=date;host, Signature=830cc36d03f0f84e6ee4953fbe701c1c8b71a0372c63af9255aa364dd183281e",
+			canonicalRequest: "GET\n/-._~0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz\n\ndate:Mon, 09 Sep 2011 23:36:00 GMT\nhost:host.foo.com\nx-amz-content-sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855\n\ndate;host;x-amz-content-sha256\ne3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+			stringToSign:     "AWS4-HMAC-SHA256\n20110909T233600Z\n20110909/us-east-1/host/aws4_request\n28e6e45f8b295710940c557546b115694d7f5bfe7bc65a3922c1d980f8dcb14a",
+			signature:        "fc33535e9ffe760da308afc673033bb2f89254ef7abe2faaf5bf7c37a64cdf91",
+			authorization:    "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20110909/us-east-1/host/aws4_request, SignedHeaders=date;host;x-amz-content-sha256, Signature=fc33535e9ffe760da308afc673033bb2f89254ef7abe2faaf5bf7c37a64cdf91",
 		},
 
 		// get-utf8
@@ -216,10 +216,10 @@ func (s *V4SignerSuite) SetUpSuite(c *C) {
 				url:     "/%E1%88%B4",
 				headers: []string{"Date:Mon, 09 Sep 2011 23:36:00 GMT"},
 			},
-			canonicalRequest: "GET\n/%E1%88%B4\n\ndate:Mon, 09 Sep 2011 23:36:00 GMT\nhost:host.foo.com\n\ndate;host\ne3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-			stringToSign:     "AWS4-HMAC-SHA256\n20110909T233600Z\n20110909/us-east-1/host/aws4_request\n27ba31df5dbc6e063d8f87d62eb07143f7f271c5330a917840586ac1c85b6f6b",
-			signature:        "8d6634c189aa8c75c2e51e106b6b5121bed103fdb351f7d7d4381c738823af74",
-			authorization:    "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20110909/us-east-1/host/aws4_request, SignedHeaders=date;host, Signature=8d6634c189aa8c75c2e51e106b6b5121bed103fdb351f7d7d4381c738823af74",
+			canonicalRequest: "GET\n/%E1%88%B4\n\ndate:Mon, 09 Sep 2011 23:36:00 GMT\nhost:host.foo.com\nx-amz-content-sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855\n\ndate;host;x-amz-content-sha256\ne3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+			stringToSign:     "AWS4-HMAC-SHA256\n20110909T233600Z\n20110909/us-east-1/host/aws4_request\n02fde5f405aa0ca5dc7851735b4ec75d0dfb6082b92f12c13abcd8f268eea660",
+			signature:        "b366e667085aa65f8b3d7be4826dce4507b2d5edd78dde12105fc44014cf65e4",
+			authorization:    "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20110909/us-east-1/host/aws4_request, SignedHeaders=date;host;x-amz-content-sha256, Signature=b366e667085aa65f8b3d7be4826dce4507b2d5edd78dde12105fc44014cf65e4",
 		},
 
 		// get-vanilla-empty-query-key
@@ -231,10 +231,10 @@ func (s *V4SignerSuite) SetUpSuite(c *C) {
 				url:     "/?foo=bar",
 				headers: []string{"Date:Mon, 09 Sep 2011 23:36:00 GMT"},
 			},
-			canonicalRequest: "GET\n/\nfoo=bar\ndate:Mon, 09 Sep 2011 23:36:00 GMT\nhost:host.foo.com\n\ndate;host\ne3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-			stringToSign:     "AWS4-HMAC-SHA256\n20110909T233600Z\n20110909/us-east-1/host/aws4_request\n0846c2945b0832deb7a463c66af5c4f8bd54ec28c438e67a214445b157c9ddf8",
-			signature:        "56c054473fd260c13e4e7393eb203662195f5d4a1fada5314b8b52b23f985e9f",
-			authorization:    "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20110909/us-east-1/host/aws4_request, SignedHeaders=date;host, Signature=56c054473fd260c13e4e7393eb203662195f5d4a1fada5314b8b52b23f985e9f",
+			canonicalRequest: "GET\n/\nfoo=bar\ndate:Mon, 09 Sep 2011 23:36:00 GMT\nhost:host.foo.com\nx-amz-content-sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855\n\ndate;host;x-amz-content-sha256\ne3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+			stringToSign:     "AWS4-HMAC-SHA256\n20110909T233600Z\n20110909/us-east-1/host/aws4_request\n763e50808f6a9e1ba0bf89728d3f34aafb9d3719350e474dbe810bf8e7b270a3",
+			signature:        "c3af9ab0d58331f70981239ab27cab9169ce2a87e5b5157b829648b084987e73",
+			authorization:    "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20110909/us-east-1/host/aws4_request, SignedHeaders=date;host;x-amz-content-sha256, Signature=c3af9ab0d58331f70981239ab27cab9169ce2a87e5b5157b829648b084987e73",
 		},
 
 		// get-vanilla-query-order-key-case
@@ -246,10 +246,10 @@ func (s *V4SignerSuite) SetUpSuite(c *C) {
 				url:     "/?foo=Zoo&foo=aha",
 				headers: []string{"Date:Mon, 09 Sep 2011 23:36:00 GMT"},
 			},
-			canonicalRequest: "GET\n/\nfoo=Zoo&foo=aha\ndate:Mon, 09 Sep 2011 23:36:00 GMT\nhost:host.foo.com\n\ndate;host\ne3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-			stringToSign:     "AWS4-HMAC-SHA256\n20110909T233600Z\n20110909/us-east-1/host/aws4_request\ne25f777ba161a0f1baf778a87faf057187cf5987f17953320e3ca399feb5f00d",
-			signature:        "be7148d34ebccdc6423b19085378aa0bee970bdc61d144bd1a8c48c33079ab09",
-			authorization:    "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20110909/us-east-1/host/aws4_request, SignedHeaders=date;host, Signature=be7148d34ebccdc6423b19085378aa0bee970bdc61d144bd1a8c48c33079ab09",
+			canonicalRequest: "GET\n/\nfoo=Zoo&foo=aha\ndate:Mon, 09 Sep 2011 23:36:00 GMT\nhost:host.foo.com\nx-amz-content-sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855\n\ndate;host;x-amz-content-sha256\ne3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+			stringToSign:     "AWS4-HMAC-SHA256\n20110909T233600Z\n20110909/us-east-1/host/aws4_request\nd651e96c251a3375a9248bacb97e05013ed9c36ebe8bb39f24be8dd522f58948",
+			signature:        "9f4456ed08b128fe09d5490f93591f1c4eaf3882a04b163920908f72c1ed7243",
+			authorization:    "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20110909/us-east-1/host/aws4_request, SignedHeaders=date;host;x-amz-content-sha256, Signature=9f4456ed08b128fe09d5490f93591f1c4eaf3882a04b163920908f72c1ed7243",
 		},
 
 		// get-vanilla-query-order-key
@@ -261,10 +261,10 @@ func (s *V4SignerSuite) SetUpSuite(c *C) {
 				url:     "/?a=foo&b=foo",
 				headers: []string{"Date:Mon, 09 Sep 2011 23:36:00 GMT"},
 			},
-			canonicalRequest: "GET\n/\na=foo&b=foo\ndate:Mon, 09 Sep 2011 23:36:00 GMT\nhost:host.foo.com\n\ndate;host\ne3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-			stringToSign:     "AWS4-HMAC-SHA256\n20110909T233600Z\n20110909/us-east-1/host/aws4_request\n2f23d14fe13caebf6dfda346285c6d9c14f49eaca8f5ec55c627dd7404f7a727",
-			signature:        "0dc122f3b28b831ab48ba65cb47300de53fbe91b577fe113edac383730254a3b",
-			authorization:    "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20110909/us-east-1/host/aws4_request, SignedHeaders=date;host, Signature=0dc122f3b28b831ab48ba65cb47300de53fbe91b577fe113edac383730254a3b",
+			canonicalRequest: "GET\n/\na=foo&b=foo\ndate:Mon, 09 Sep 2011 23:36:00 GMT\nhost:host.foo.com\nx-amz-content-sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855\n\ndate;host;x-amz-content-sha256\ne3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+			stringToSign:     "AWS4-HMAC-SHA256\n20110909T233600Z\n20110909/us-east-1/host/aws4_request\n1da40574a1309ebbd7b2c4523059d1b6acd99ac198fc6ae5e0f5f90e85726e75",
+			signature:        "800aed7d844fd17d0b98bbfcabfb0f4fc79fc9d2aae345baf75d696df36241d7",
+			authorization:    "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20110909/us-east-1/host/aws4_request, SignedHeaders=date;host;x-amz-content-sha256, Signature=800aed7d844fd17d0b98bbfcabfb0f4fc79fc9d2aae345baf75d696df36241d7",
 		},
 
 		// get-vanilla-query-order-value
@@ -276,10 +276,10 @@ func (s *V4SignerSuite) SetUpSuite(c *C) {
 				url:     "/?foo=b&foo=a",
 				headers: []string{"Date:Mon, 09 Sep 2011 23:36:00 GMT"},
 			},
-			canonicalRequest: "GET\n/\nfoo=a&foo=b\ndate:Mon, 09 Sep 2011 23:36:00 GMT\nhost:host.foo.com\n\ndate;host\ne3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-			stringToSign:     "AWS4-HMAC-SHA256\n20110909T233600Z\n20110909/us-east-1/host/aws4_request\n33dffc220e89131f8f6157a35c40903daa658608d9129ff9489e5cf5bbd9b11b",
-			signature:        "feb926e49e382bec75c9d7dcb2a1b6dc8aa50ca43c25d2bc51143768c0875acc",
-			authorization:    "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20110909/us-east-1/host/aws4_request, SignedHeaders=date;host, Signature=feb926e49e382bec75c9d7dcb2a1b6dc8aa50ca43c25d2bc51143768c0875acc",
+			canonicalRequest: "GET\n/\nfoo=a&foo=b\ndate:Mon, 09 Sep 2011 23:36:00 GMT\nhost:host.foo.com\nx-amz-content-sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855\n\ndate;host;x-amz-content-sha256\ne3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+			stringToSign:     "AWS4-HMAC-SHA256\n20110909T233600Z\n20110909/us-east-1/host/aws4_request\n781593a5fd3c02af91b2956df4c1f56305bc2289cb88179df74f905e9108854b",
+			signature:        "0784708ecdb06ffca4f0e2cffb2825849f1fa5c947bd91da312403d3ac060ba8",
+			authorization:    "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20110909/us-east-1/host/aws4_request, SignedHeaders=date;host;x-amz-content-sha256, Signature=0784708ecdb06ffca4f0e2cffb2825849f1fa5c947bd91da312403d3ac060ba8",
 		},
 
 		// get-vanilla-query-unreserved
@@ -291,10 +291,10 @@ func (s *V4SignerSuite) SetUpSuite(c *C) {
 				url:     "/?-._~0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz=-._~0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz",
 				headers: []string{"Date:Mon, 09 Sep 2011 23:36:00 GMT"},
 			},
-			canonicalRequest: "GET\n/\n-._~0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz=-._~0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz\ndate:Mon, 09 Sep 2011 23:36:00 GMT\nhost:host.foo.com\n\ndate;host\ne3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-			stringToSign:     "AWS4-HMAC-SHA256\n20110909T233600Z\n20110909/us-east-1/host/aws4_request\nd2578f3156d4c9d180713d1ff20601d8a3eed0dd35447d24603d7d67414bd6b5",
-			signature:        "f1498ddb4d6dae767d97c466fb92f1b59a2c71ca29ac954692663f9db03426fb",
-			authorization:    "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20110909/us-east-1/host/aws4_request, SignedHeaders=date;host, Signature=f1498ddb4d6dae767d97c466fb92f1b59a2c71ca29ac954692663f9db03426fb",
+			canonicalRequest: "GET\n/\n-._~0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz=-._~0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz\ndate:Mon, 09 Sep 2011 23:36:00 GMT\nhost:host.foo.com\nx-amz-content-sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855\n\ndate;host;x-amz-content-sha256\ne3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+			stringToSign:     "AWS4-HMAC-SHA256\n20110909T233600Z\n20110909/us-east-1/host/aws4_request\neddf477a78e0d7fd1617d20021167184e11634e9b3cccb472fae4881555c7585",
+			signature:        "032038308853317f8898d90c3678a1e269e68e30e50fb97c6654eaeff9480799",
+			authorization:    "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20110909/us-east-1/host/aws4_request, SignedHeaders=date;host;x-amz-content-sha256, Signature=032038308853317f8898d90c3678a1e269e68e30e50fb97c6654eaeff9480799",
 		},
 
 		// get-vanilla-query
@@ -306,10 +306,10 @@ func (s *V4SignerSuite) SetUpSuite(c *C) {
 				url:     "/",
 				headers: []string{"Date:Mon, 09 Sep 2011 23:36:00 GMT"},
 			},
-			canonicalRequest: "GET\n/\n\ndate:Mon, 09 Sep 2011 23:36:00 GMT\nhost:host.foo.com\n\ndate;host\ne3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-			stringToSign:     "AWS4-HMAC-SHA256\n20110909T233600Z\n20110909/us-east-1/host/aws4_request\n366b91fb121d72a00f46bbe8d395f53a102b06dfb7e79636515208ed3fa606b1",
-			signature:        "b27ccfbfa7df52a200ff74193ca6e32d4b48b8856fab7ebf1c595d0670a7e470",
-			authorization:    "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20110909/us-east-1/host/aws4_request, SignedHeaders=date;host, Signature=b27ccfbfa7df52a200ff74193ca6e32d4b48b8856fab7ebf1c595d0670a7e470",
+			canonicalRequest: "GET\n/\n\ndate:Mon, 09 Sep 2011 23:36:00 GMT\nhost:host.foo.com\nx-amz-content-sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855\n\ndate;host;x-amz-content-sha256\ne3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+			stringToSign:     "AWS4-HMAC-SHA256\n20110909T233600Z\n20110909/us-east-1/host/aws4_request\nedf3a954ef9b74cf366ad17b25bc502050eb85bcd3d86b24431cb9aea8761c84",
+			signature:        "6ad5d9fd6d93c5855f08c4675163da70623fcca6f49f9c96a3890c1c32877a2e",
+			authorization:    "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20110909/us-east-1/host/aws4_request, SignedHeaders=date;host;x-amz-content-sha256, Signature=6ad5d9fd6d93c5855f08c4675163da70623fcca6f49f9c96a3890c1c32877a2e",
 		},
 
 		// get-vanilla-ut8-query
@@ -321,10 +321,10 @@ func (s *V4SignerSuite) SetUpSuite(c *C) {
 				url:     "/?ሴ=bar",
 				headers: []string{"Date:Mon, 09 Sep 2011 23:36:00 GMT"},
 			},
-			canonicalRequest: "GET\n/\n%E1%88%B4=bar\ndate:Mon, 09 Sep 2011 23:36:00 GMT\nhost:host.foo.com\n\ndate;host\ne3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-			stringToSign:     "AWS4-HMAC-SHA256\n20110909T233600Z\n20110909/us-east-1/host/aws4_request\nde5065ff39c131e6c2e2bd19cd9345a794bf3b561eab20b8d97b2093fc2a979e",
-			signature:        "6fb359e9a05394cc7074e0feb42573a2601abc0c869a953e8c5c12e4e01f1a8c",
-			authorization:    "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20110909/us-east-1/host/aws4_request, SignedHeaders=date;host, Signature=6fb359e9a05394cc7074e0feb42573a2601abc0c869a953e8c5c12e4e01f1a8c",
+			canonicalRequest: "GET\n/\n%E1%88%B4=bar\ndate:Mon, 09 Sep 2011 23:36:00 GMT\nhost:host.foo.com\nx-amz-content-sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855\n\ndate;host;x-amz-content-sha256\ne3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+			stringToSign:     "AWS4-HMAC-SHA256\n20110909T233600Z\n20110909/us-east-1/host/aws4_request\ne06a77d8fca5b57869e3a5b84b6147b8a38bb8caecbe7e14c2b5d2a0f98df7ec",
+			signature:        "05991e997a8d3bab48124e73396fe4826fb47b714072423d765a2a3bdd4a2a7c",
+			authorization:    "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20110909/us-east-1/host/aws4_request, SignedHeaders=date;host;x-amz-content-sha256, Signature=05991e997a8d3bab48124e73396fe4826fb47b714072423d765a2a3bdd4a2a7c",
 		},
 
 		// get-vanilla
@@ -336,10 +336,10 @@ func (s *V4SignerSuite) SetUpSuite(c *C) {
 				url:     "/",
 				headers: []string{"Date:Mon, 09 Sep 2011 23:36:00 GMT"},
 			},
-			canonicalRequest: "GET\n/\n\ndate:Mon, 09 Sep 2011 23:36:00 GMT\nhost:host.foo.com\n\ndate;host\ne3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-			stringToSign:     "AWS4-HMAC-SHA256\n20110909T233600Z\n20110909/us-east-1/host/aws4_request\n366b91fb121d72a00f46bbe8d395f53a102b06dfb7e79636515208ed3fa606b1",
-			signature:        "b27ccfbfa7df52a200ff74193ca6e32d4b48b8856fab7ebf1c595d0670a7e470",
-			authorization:    "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20110909/us-east-1/host/aws4_request, SignedHeaders=date;host, Signature=b27ccfbfa7df52a200ff74193ca6e32d4b48b8856fab7ebf1c595d0670a7e470",
+			canonicalRequest: "GET\n/\n\ndate:Mon, 09 Sep 2011 23:36:00 GMT\nhost:host.foo.com\nx-amz-content-sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855\n\ndate;host;x-amz-content-sha256\ne3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+			stringToSign:     "AWS4-HMAC-SHA256\n20110909T233600Z\n20110909/us-east-1/host/aws4_request\nedf3a954ef9b74cf366ad17b25bc502050eb85bcd3d86b24431cb9aea8761c84",
+			signature:        "6ad5d9fd6d93c5855f08c4675163da70623fcca6f49f9c96a3890c1c32877a2e",
+			authorization:    "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20110909/us-east-1/host/aws4_request, SignedHeaders=date;host;x-amz-content-sha256, Signature=6ad5d9fd6d93c5855f08c4675163da70623fcca6f49f9c96a3890c1c32877a2e",
 		},
 
 		// post-header-key-case
@@ -351,10 +351,10 @@ func (s *V4SignerSuite) SetUpSuite(c *C) {
 				url:     "/",
 				headers: []string{"DATE:Mon, 09 Sep 2011 23:36:00 GMT"},
 			},
-			canonicalRequest: "POST\n/\n\ndate:Mon, 09 Sep 2011 23:36:00 GMT\nhost:host.foo.com\n\ndate;host\ne3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-			stringToSign:     "AWS4-HMAC-SHA256\n20110909T233600Z\n20110909/us-east-1/host/aws4_request\n05da62cee468d24ae84faff3c39f1b85540de60243c1bcaace39c0a2acc7b2c4",
-			signature:        "22902d79e148b64e7571c3565769328423fe276eae4b26f83afceda9e767f726",
-			authorization:    "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20110909/us-east-1/host/aws4_request, SignedHeaders=date;host, Signature=22902d79e148b64e7571c3565769328423fe276eae4b26f83afceda9e767f726",
+			canonicalRequest: "POST\n/\n\ndate:Mon, 09 Sep 2011 23:36:00 GMT\nhost:host.foo.com\nx-amz-content-sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855\n\ndate;host;x-amz-content-sha256\ne3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+			stringToSign:     "AWS4-HMAC-SHA256\n20110909T233600Z\n20110909/us-east-1/host/aws4_request\ne99db283d41c8d76b65f2bde6003746997018685efaf38028979f3b4c01b9fdd",
+			signature:        "1f2d4161c5845a97c13548fd1f6421c1a5930730a177e00c3684579c68a99d1e",
+			authorization:    "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20110909/us-east-1/host/aws4_request, SignedHeaders=date;host;x-amz-content-sha256, Signature=1f2d4161c5845a97c13548fd1f6421c1a5930730a177e00c3684579c68a99d1e",
 		},
 
 		// post-header-key-sort
@@ -366,10 +366,10 @@ func (s *V4SignerSuite) SetUpSuite(c *C) {
 				url:     "/",
 				headers: []string{"DATE:Mon, 09 Sep 2011 23:36:00 GMT", "ZOO:zoobar"},
 			},
-			canonicalRequest: "POST\n/\n\ndate:Mon, 09 Sep 2011 23:36:00 GMT\nhost:host.foo.com\nzoo:zoobar\n\ndate;host;zoo\ne3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-			stringToSign:     "AWS4-HMAC-SHA256\n20110909T233600Z\n20110909/us-east-1/host/aws4_request\n34e1bddeb99e76ee01d63b5e28656111e210529efeec6cdfd46a48e4c734545d",
-			signature:        "b7a95a52518abbca0964a999a880429ab734f35ebbf1235bd79a5de87756dc4a",
-			authorization:    "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20110909/us-east-1/host/aws4_request, SignedHeaders=date;host;zoo, Signature=b7a95a52518abbca0964a999a880429ab734f35ebbf1235bd79a5de87756dc4a",
+			canonicalRequest: "POST\n/\n\ndate:Mon, 09 Sep 2011 23:36:00 GMT\nhost:host.foo.com\nx-amz-content-sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855\nzoo:zoobar\n\ndate;host;x-amz-content-sha256;zoo\ne3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+			stringToSign:     "AWS4-HMAC-SHA256\n20110909T233600Z\n20110909/us-east-1/host/aws4_request\nfec201022f7e94b0c824b3485230ca29fd026618dc8d759923aa48bc581762ed",
+			signature:        "7daf56768cfc0d366c47044fbf00fda5e7b80043cf55c316317ef29a83e2555c",
+			authorization:    "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20110909/us-east-1/host/aws4_request, SignedHeaders=date;host;x-amz-content-sha256;zoo, Signature=7daf56768cfc0d366c47044fbf00fda5e7b80043cf55c316317ef29a83e2555c",
 		},
 
 		// post-header-value-case
@@ -381,10 +381,10 @@ func (s *V4SignerSuite) SetUpSuite(c *C) {
 				url:     "/",
 				headers: []string{"DATE:Mon, 09 Sep 2011 23:36:00 GMT", "zoo:ZOOBAR"},
 			},
-			canonicalRequest: "POST\n/\n\ndate:Mon, 09 Sep 2011 23:36:00 GMT\nhost:host.foo.com\nzoo:ZOOBAR\n\ndate;host;zoo\ne3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-			stringToSign:     "AWS4-HMAC-SHA256\n20110909T233600Z\n20110909/us-east-1/host/aws4_request\n3aae6d8274b8c03e2cc96fc7d6bda4b9bd7a0a184309344470b2c96953e124aa",
-			signature:        "273313af9d0c265c531e11db70bbd653f3ba074c1009239e8559d3987039cad7",
-			authorization:    "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20110909/us-east-1/host/aws4_request, SignedHeaders=date;host;zoo, Signature=273313af9d0c265c531e11db70bbd653f3ba074c1009239e8559d3987039cad7",
+			canonicalRequest: "POST\n/\n\ndate:Mon, 09 Sep 2011 23:36:00 GMT\nhost:host.foo.com\nx-amz-content-sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855\nzoo:ZOOBAR\n\ndate;host;x-amz-content-sha256;zoo\ne3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+			stringToSign:     "AWS4-HMAC-SHA256\n20110909T233600Z\n20110909/us-east-1/host/aws4_request\nfe62c1b0b49383f0a25e528d62a5fba9fce82a01db9a9e37dc5f2fd70fe55e08",
+			signature:        "9fd3fe58fa020bd61f0899abcb638d335bd91fe85a0bd26a8ee272164a1a122e",
+			authorization:    "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20110909/us-east-1/host/aws4_request, SignedHeaders=date;host;x-amz-content-sha256;zoo, Signature=9fd3fe58fa020bd61f0899abcb638d335bd91fe85a0bd26a8ee272164a1a122e",
 		},
 
 		// post-vanilla-empty-query-value
@@ -396,10 +396,10 @@ func (s *V4SignerSuite) SetUpSuite(c *C) {
 				url:     "/?foo=bar",
 				headers: []string{"Date:Mon, 09 Sep 2011 23:36:00 GMT"},
 			},
-			canonicalRequest: "POST\n/\nfoo=bar\ndate:Mon, 09 Sep 2011 23:36:00 GMT\nhost:host.foo.com\n\ndate;host\ne3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-			stringToSign:     "AWS4-HMAC-SHA256\n20110909T233600Z\n20110909/us-east-1/host/aws4_request\ncd4f39132d8e60bb388831d734230460872b564871c47f5de62e62d1a68dbe1e",
-			signature:        "b6e3b79003ce0743a491606ba1035a804593b0efb1e20a11cba83f8c25a57a92",
-			authorization:    "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20110909/us-east-1/host/aws4_request, SignedHeaders=date;host, Signature=b6e3b79003ce0743a491606ba1035a804593b0efb1e20a11cba83f8c25a57a92",
+			canonicalRequest: "POST\n/\nfoo=bar\ndate:Mon, 09 Sep 2011 23:36:00 GMT\nhost:host.foo.com\nx-amz-content-sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855\n\ndate;host;x-amz-content-sha256\ne3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+			stringToSign:     "AWS4-HMAC-SHA256\n20110909T233600Z\n20110909/us-east-1/host/aws4_request\n48d51a068e0fe8aff12e1f1278aad9d750ce3633480760373c9d2d1556ce2ac3",
+			signature:        "8e7cde9089c5c8675dc1306869fd1f2089d84f5008c86332bcb4def9245b15a4",
+			authorization:    "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20110909/us-east-1/host/aws4_request, SignedHeaders=date;host;x-amz-content-sha256, Signature=8e7cde9089c5c8675dc1306869fd1f2089d84f5008c86332bcb4def9245b15a4",
 		},
 
 		// post-vanilla-query
@@ -411,10 +411,10 @@ func (s *V4SignerSuite) SetUpSuite(c *C) {
 				url:     "/?foo=bar",
 				headers: []string{"Date:Mon, 09 Sep 2011 23:36:00 GMT"},
 			},
-			canonicalRequest: "POST\n/\nfoo=bar\ndate:Mon, 09 Sep 2011 23:36:00 GMT\nhost:host.foo.com\n\ndate;host\ne3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-			stringToSign:     "AWS4-HMAC-SHA256\n20110909T233600Z\n20110909/us-east-1/host/aws4_request\ncd4f39132d8e60bb388831d734230460872b564871c47f5de62e62d1a68dbe1e",
-			signature:        "b6e3b79003ce0743a491606ba1035a804593b0efb1e20a11cba83f8c25a57a92",
-			authorization:    "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20110909/us-east-1/host/aws4_request, SignedHeaders=date;host, Signature=b6e3b79003ce0743a491606ba1035a804593b0efb1e20a11cba83f8c25a57a92",
+			canonicalRequest: "POST\n/\nfoo=bar\ndate:Mon, 09 Sep 2011 23:36:00 GMT\nhost:host.foo.com\nx-amz-content-sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855\n\ndate;host;x-amz-content-sha256\ne3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+			stringToSign:     "AWS4-HMAC-SHA256\n20110909T233600Z\n20110909/us-east-1/host/aws4_request\n48d51a068e0fe8aff12e1f1278aad9d750ce3633480760373c9d2d1556ce2ac3",
+			signature:        "8e7cde9089c5c8675dc1306869fd1f2089d84f5008c86332bcb4def9245b15a4",
+			authorization:    "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20110909/us-east-1/host/aws4_request, SignedHeaders=date;host;x-amz-content-sha256, Signature=8e7cde9089c5c8675dc1306869fd1f2089d84f5008c86332bcb4def9245b15a4",
 		},
 
 		// post-vanilla
@@ -426,10 +426,10 @@ func (s *V4SignerSuite) SetUpSuite(c *C) {
 				url:     "/",
 				headers: []string{"Date:Mon, 09 Sep 2011 23:36:00 GMT"},
 			},
-			canonicalRequest: "POST\n/\n\ndate:Mon, 09 Sep 2011 23:36:00 GMT\nhost:host.foo.com\n\ndate;host\ne3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-			stringToSign:     "AWS4-HMAC-SHA256\n20110909T233600Z\n20110909/us-east-1/host/aws4_request\n05da62cee468d24ae84faff3c39f1b85540de60243c1bcaace39c0a2acc7b2c4",
-			signature:        "22902d79e148b64e7571c3565769328423fe276eae4b26f83afceda9e767f726",
-			authorization:    "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20110909/us-east-1/host/aws4_request, SignedHeaders=date;host, Signature=22902d79e148b64e7571c3565769328423fe276eae4b26f83afceda9e767f726",
+			canonicalRequest: "POST\n/\n\ndate:Mon, 09 Sep 2011 23:36:00 GMT\nhost:host.foo.com\nx-amz-content-sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855\n\ndate;host;x-amz-content-sha256\ne3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+			stringToSign:     "AWS4-HMAC-SHA256\n20110909T233600Z\n20110909/us-east-1/host/aws4_request\ne99db283d41c8d76b65f2bde6003746997018685efaf38028979f3b4c01b9fdd",
+			signature:        "1f2d4161c5845a97c13548fd1f6421c1a5930730a177e00c3684579c68a99d1e",
+			authorization:    "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20110909/us-east-1/host/aws4_request, SignedHeaders=date;host;x-amz-content-sha256, Signature=1f2d4161c5845a97c13548fd1f6421c1a5930730a177e00c3684579c68a99d1e",
 		},
 
 		// post-x-www-form-urlencoded-parameters
@@ -442,10 +442,10 @@ func (s *V4SignerSuite) SetUpSuite(c *C) {
 				headers: []string{"Content-Type:application/x-www-form-urlencoded; charset=utf8", "Date:Mon, 09 Sep 2011 23:36:00 GMT"},
 				body:    "foo=bar",
 			},
-			canonicalRequest: "POST\n/\n\ncontent-type:application/x-www-form-urlencoded; charset=utf8\ndate:Mon, 09 Sep 2011 23:36:00 GMT\nhost:host.foo.com\n\ncontent-type;date;host\n3ba8907e7a252327488df390ed517c45b96dead033600219bdca7107d1d3f88a",
-			stringToSign:     "AWS4-HMAC-SHA256\n20110909T233600Z\n20110909/us-east-1/host/aws4_request\nc4115f9e54b5cecf192b1eaa23b8e88ed8dc5391bd4fde7b3fff3d9c9fe0af1f",
-			signature:        "b105eb10c6d318d2294de9d49dd8b031b55e3c3fe139f2e637da70511e9e7b71",
-			authorization:    "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20110909/us-east-1/host/aws4_request, SignedHeaders=content-type;date;host, Signature=b105eb10c6d318d2294de9d49dd8b031b55e3c3fe139f2e637da70511e9e7b71",
+			canonicalRequest: "POST\n/\n\ncontent-type:application/x-www-form-urlencoded; charset=utf8\ndate:Mon, 09 Sep 2011 23:36:00 GMT\nhost:host.foo.com\nx-amz-content-sha256:3ba8907e7a252327488df390ed517c45b96dead033600219bdca7107d1d3f88a\n\ncontent-type;date;host;x-amz-content-sha256\n3ba8907e7a252327488df390ed517c45b96dead033600219bdca7107d1d3f88a",
+			stringToSign:     "AWS4-HMAC-SHA256\n20110909T233600Z\n20110909/us-east-1/host/aws4_request\ndfae45948f3fdc5780d014f391042d4e220f577961bb96b84f7bbf8e1a91fe5e",
+			signature:        "3bfa5e222990f3f1f14e746a68568a647a210c0705a869e9c19b40d8c86ca309",
+			authorization:    "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20110909/us-east-1/host/aws4_request, SignedHeaders=content-type;date;host;x-amz-content-sha256, Signature=3bfa5e222990f3f1f14e746a68568a647a210c0705a869e9c19b40d8c86ca309",
 		},
 
 		// post-x-www-form-urlencoded
@@ -458,16 +458,16 @@ func (s *V4SignerSuite) SetUpSuite(c *C) {
 				headers: []string{"Content-Type:application/x-www-form-urlencoded", "Date:Mon, 09 Sep 2011 23:36:00 GMT"},
 				body:    "foo=bar",
 			},
-			canonicalRequest: "POST\n/\n\ncontent-type:application/x-www-form-urlencoded\ndate:Mon, 09 Sep 2011 23:36:00 GMT\nhost:host.foo.com\n\ncontent-type;date;host\n3ba8907e7a252327488df390ed517c45b96dead033600219bdca7107d1d3f88a",
-			stringToSign:     "AWS4-HMAC-SHA256\n20110909T233600Z\n20110909/us-east-1/host/aws4_request\n4c5c6e4b52fb5fb947a8733982a8a5a61b14f04345cbfe6e739236c76dd48f74",
-			signature:        "5a15b22cf462f047318703b92e6f4f38884e4a7ab7b1d6426ca46a8bd1c26cbc",
-			authorization:    "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20110909/us-east-1/host/aws4_request, SignedHeaders=content-type;date;host, Signature=5a15b22cf462f047318703b92e6f4f38884e4a7ab7b1d6426ca46a8bd1c26cbc",
+			canonicalRequest: "POST\n/\n\ncontent-type:application/x-www-form-urlencoded\ndate:Mon, 09 Sep 2011 23:36:00 GMT\nhost:host.foo.com\nx-amz-content-sha256:3ba8907e7a252327488df390ed517c45b96dead033600219bdca7107d1d3f88a\n\ncontent-type;date;host;x-amz-content-sha256\n3ba8907e7a252327488df390ed517c45b96dead033600219bdca7107d1d3f88a",
+			stringToSign:     "AWS4-HMAC-SHA256\n20110909T233600Z\n20110909/us-east-1/host/aws4_request\n8434678b03c6f956b391ec4423570bc1f0be17aa53b81118dbba82873a64b700",
+			signature:        "771ad8937d4a60e1b926fd12b91c01d904afeada0acf79c019b4c2827c902670",
+			authorization:    "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20110909/us-east-1/host/aws4_request, SignedHeaders=content-type;date;host;x-amz-content-sha256, Signature=771ad8937d4a60e1b926fd12b91c01d904afeada0acf79c019b4c2827c902670",
 		},
 	)
 }
 
 func (s *V4SignerSuite) TestCases(c *C) {
-	signer := aws.NewV4Signer(s.auth, "host", s.region)
+	signer := aws.NewV4Signer(s.auth, "host", s.region.Name)
 
 	for _, testCase := range s.cases {
 
@@ -481,7 +481,7 @@ func (s *V4SignerSuite) TestCases(c *C) {
 
 		t := signer.RequestTime(req)
 
-		canonicalRequest := signer.CanonicalRequest(req)
+		canonicalRequest, _ := signer.CanonicalRequest(req)
 		c.Check(canonicalRequest, Equals, testCase.canonicalRequest, Commentf("Testcase: %s", testCase.label))
 
 		stringToSign := signer.StringToSign(t, canonicalRequest)
@@ -506,7 +506,7 @@ func ExampleV4Signer() {
 	}
 
 	// Create a signer with the auth, name of the service, and aws region
-	signer := aws.NewV4Signer(auth, "dynamodb", aws.USEast)
+	signer := aws.NewV4Signer(auth, "dynamodb", aws.USEast.Name)
 
 	// Create a request
 	req, err := http.NewRequest("POST", aws.USEast.DynamoDBEndpoint, strings.NewReader("sample_request"))

--- a/cloudformation/cloudformation.go
+++ b/cloudformation/cloudformation.go
@@ -83,7 +83,7 @@ func (c *CloudFormation) query(params map[string]string, resp interface{}) error
 		hreq.Header.Set("X-Amz-Security-Token", token)
 	}
 
-	signer := aws.NewV4Signer(c.Auth, "cloudformation", c.Region)
+	signer := aws.NewV4Signer(c.Auth, "cloudformation", c.Region.Name)
 	signer.Sign(hreq)
 
 	if debug {
@@ -103,7 +103,7 @@ func (c *CloudFormation) query(params map[string]string, resp interface{}) error
 		log.Printf("response:\n")
 		log.Printf("%v\n}\n", string(dump))
 	}
-	if r.StatusCode != 200 {
+	if r.StatusCode != http.StatusOK {
 		return buildError(r)
 	}
 	err = xml.NewDecoder(r.Body).Decode(resp)

--- a/cloudwatch/README.md
+++ b/cloudwatch/README.md
@@ -55,7 +55,7 @@ func test_get_metric_statistics() {
        os.Exit(1)
     }
 
-    cw, err := cloudwatch.NewCloudWatch(auth, region.CloudWatchServicepoint)
+    cw, err := cloudwatch.NewCloudWatch(auth, region)
     request := &cloudwatch.GetMetricStatisticsRequest {
                 Dimensions: []cloudwatch.Dimension{*dimension},
                 EndTime: now,
@@ -96,7 +96,7 @@ func test_list_metrics() {
        fmt.Printf("Error: %+v\n", err)
        os.Exit(1)
     }
-    cw, err := cloudwatch.NewCloudWatch(auth, region.CloudWatchServicepoint)
+    cw, err := cloudwatch.NewCloudWatch(auth, region)
     request := &cloudwatch.ListMetricsRequest{Namespace: "AWS/EC2"}
 
     response, err := cw.ListMetrics(request)

--- a/cloudwatch/cloudwatch.go
+++ b/cloudwatch/cloudwatch.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"github.com/feyeleanor/sets"
 	"github.com/goamz/goamz/aws"
+	"net/http"
 	"strconv"
 	"time"
 )
@@ -177,8 +178,8 @@ var validComparisonOperators = sets.SSet(
 )
 
 // Create a new CloudWatch object for a given namespace
-func NewCloudWatch(auth aws.Auth, region aws.ServiceInfo) (*CloudWatch, error) {
-	service, err := aws.NewService(auth, region)
+func NewCloudWatch(auth aws.Auth, region aws.Region) (*CloudWatch, error) {
+	service, err := aws.NewService(auth, region.CloudWatchEndpoint, region, "monitoring")
 	if err != nil {
 		return nil, err
 	}
@@ -197,7 +198,7 @@ func (c *CloudWatch) query(method, path string, params map[string]string, resp i
 	}
 	defer r.Body.Close()
 
-	if r.StatusCode != 200 {
+	if r.StatusCode != http.StatusOK {
 		return c.Service.BuildError(r)
 	}
 	err = xml.NewDecoder(r.Body).Decode(resp)

--- a/cloudwatch/cloudwatch_test.go
+++ b/cloudwatch/cloudwatch_test.go
@@ -24,7 +24,9 @@ var testServer = testutil.NewHTTPServer()
 func (s *S) SetUpSuite(c *C) {
 	testServer.Start()
 	auth := aws.Auth{AccessKey: "abc", SecretKey: "123"}
-	s.cw, _ = cloudwatch.NewCloudWatch(auth, aws.ServiceInfo{testServer.URL, aws.V2Signature})
+	region := aws.USEast
+	region.CloudWatchEndpoint = testServer.URL
+	s.cw, _ = cloudwatch.NewCloudWatch(auth, region)
 }
 
 func (s *S) TearDownTest(c *C) {

--- a/ec2/ec2.go
+++ b/ec2/ec2.go
@@ -152,7 +152,7 @@ func (ec2 *EC2) query(params map[string]string, resp interface{}) error {
 		log.Printf("response:\n")
 		log.Printf("%v\n}\n", string(dump))
 	}
-	if r.StatusCode != 200 {
+	if r.StatusCode != http.StatusOK {
 		return buildError(r)
 	}
 	err = xml.NewDecoder(r.Body).Decode(resp)

--- a/ecs/ecs.go
+++ b/ecs/ecs.go
@@ -84,8 +84,9 @@ func (e *ECS) query(params map[string]string, resp interface{}) error {
 		hreq.Header.Set("X-Amz-Security-Token", token)
 	}
 
-	signer := aws.NewV4Signer(e.Auth, "ecs", e.Region)
-	signer.Sign(hreq)
+	if err = aws.SignV4(hreq, e.Auth, "ecs", e.Region.Name); err != nil {
+		return err
+	}
 
 	if debug {
 		log.Printf("%v -> {\n", hreq)
@@ -104,7 +105,7 @@ func (e *ECS) query(params map[string]string, resp interface{}) error {
 		log.Printf("response:\n")
 		log.Printf("%v\n}\n", string(dump))
 	}
-	if r.StatusCode != 200 {
+	if r.StatusCode != http.StatusOK {
 		return buildError(r)
 	}
 	err = xml.NewDecoder(r.Body).Decode(resp)

--- a/exp/mturk/mturk.go
+++ b/exp/mturk/mturk.go
@@ -452,7 +452,7 @@ func (mt *MTurk) query(params map[string]string, operation string, resp interfac
 	}
 	//dump, _ := httputil.DumpResponse(r, true)
 	//println("DUMP:\n", string(dump))
-	if r.StatusCode != 200 {
+	if r.StatusCode != http.StatusOK {
 		return errors.New(fmt.Sprintf("%d: unexpected status code", r.StatusCode))
 	}
 	dec := xml.NewDecoder(r.Body)

--- a/exp/sdb/sdb.go
+++ b/exp/sdb/sdb.go
@@ -397,7 +397,7 @@ func (sdb *SDB) query(domain *Domain, item *Item, params url.Values, headers htt
 	}
 
 	// status code is always 200 when successful (since we're always doing a GET)
-	if r.StatusCode != 200 {
+	if r.StatusCode != http.StatusOK {
 		return buildError(r)
 	}
 

--- a/exp/ses/ses.go
+++ b/exp/ses/ses.go
@@ -130,7 +130,7 @@ func (ses *SES) doPost(action string, data url.Values) error {
 	if err != nil {
 		return err
 	}
-	if resp.StatusCode > 204 {
+	if resp.StatusCode > http.StatusNoContent {
 		defer resp.Body.Close()
 		return buildError(resp)
 	}

--- a/exp/sns/sns.go
+++ b/exp/sns/sns.go
@@ -82,7 +82,7 @@ func (sns *SNS) query(params map[string]string, resp interface{}) error {
 	}
 	defer r.Body.Close()
 
-	if r.StatusCode != 200 {
+	if r.StatusCode != http.StatusOK {
 		return buildError(r)
 	}
 	err = xml.NewDecoder(r.Body).Decode(resp)

--- a/iam/iam.go
+++ b/iam/iam.go
@@ -43,7 +43,7 @@ func (iam *IAM) query(params map[string]string, resp interface{}) error {
 		return err
 	}
 	defer r.Body.Close()
-	if r.StatusCode > 200 {
+	if r.StatusCode > http.StatusOK {
 		return buildError(r)
 	}
 
@@ -72,7 +72,7 @@ func (iam *IAM) postQuery(params map[string]string, resp interface{}) error {
 		return err
 	}
 	defer r.Body.Close()
-	if r.StatusCode > 200 {
+	if r.StatusCode > http.StatusOK {
 		return buildError(r)
 	}
 	return xml.NewDecoder(r.Body).Decode(resp)

--- a/rds/rds.go
+++ b/rds/rds.go
@@ -4,6 +4,7 @@ import (
 	"encoding/xml"
 	"github.com/goamz/goamz/aws"
 	"log"
+	"net/http"
 	"net/http/httputil"
 	"strconv"
 )
@@ -22,7 +23,7 @@ type RDS struct {
 
 // New creates a new RDS Client.
 func New(auth aws.Auth, region aws.Region) (*RDS, error) {
-	service, err := aws.NewService(auth, region.RDSEndpoint)
+	service, err := aws.NewService(auth, region.RDSEndpoint, region, "rds")
 	if err != nil {
 		return nil, err
 	}
@@ -51,7 +52,7 @@ func (rds *RDS) query(method, path string, params map[string]string, resp interf
 		log.Printf("%v\n}\n", string(dump))
 	}
 
-	if r.StatusCode != 200 {
+	if r.StatusCode != http.StatusOK {
 		return rds.Service.BuildError(r)
 	}
 	err = xml.NewDecoder(r.Body).Decode(resp)

--- a/rds/rds_test.go
+++ b/rds/rds_test.go
@@ -25,7 +25,7 @@ func (s *S) SetUpSuite(c *C) {
 	var err error
 	testServer.Start()
 	auth := aws.Auth{AccessKey: "abc", SecretKey: "123"}
-	s.rds, err = rds.New(auth, aws.Region{RDSEndpoint: aws.ServiceInfo{testServer.URL, aws.V2Signature}})
+	s.rds, err = rds.New(auth, aws.Region{RDSEndpoint: testServer.URL})
 	c.Assert(err, IsNil)
 }
 

--- a/route53/route53.go
+++ b/route53/route53.go
@@ -181,7 +181,7 @@ func (r *Route53) query(method string, path string, body io.Reader, result inter
 		defer req.Body.Close()
 	}
 
-	if res.StatusCode != 201 && res.StatusCode != 200 {
+	if res.StatusCode != http.StatusCreated && res.StatusCode != http.StatusOK {
 		err = r.Service.BuildError(res)
 		return err
 	}

--- a/s3/multi.go
+++ b/s3/multi.go
@@ -171,11 +171,11 @@ func (m *Multi) putPart(n int, r io.ReadSeeker, partSize int64, md5b64 string) (
 			params:  params,
 			payload: r,
 		}
-		err = m.Bucket.S3.prepare(req)
+		hreq, err := m.Bucket.S3.prepare(req)
 		if err != nil {
 			return Part{}, err
 		}
-		resp, err := m.Bucket.S3.run(req, nil)
+		resp, err := m.Bucket.S3.run(hreq, nil)
 		if shouldRetry(err) && attempt.HasNext() {
 			continue
 		}

--- a/s3/s3.go
+++ b/s3/s3.go
@@ -28,6 +28,7 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -253,12 +254,12 @@ func (b *Bucket) GetResponseWithHeaders(path string, headers map[string][]string
 		path:    path,
 		headers: headers,
 	}
-	err = b.S3.prepare(req)
+	hreq, err := b.S3.prepare(req)
 	if err != nil {
 		return nil, err
 	}
 	for attempt := b.S3.AttemptStrategy.Start(); attempt.Next(); {
-		resp, err := b.S3.run(req, nil)
+		resp, err := b.S3.run(hreq, nil)
 		if shouldRetry(err) && attempt.HasNext() {
 			continue
 		}
@@ -277,12 +278,13 @@ func (b *Bucket) Exists(path string) (exists bool, err error) {
 		bucket: b.Name,
 		path:   path,
 	}
-	err = b.S3.prepare(req)
-	if err != nil {
+
+	var hreq *http.Request
+	if hreq, err = b.S3.prepare(req); err != nil {
 		return
 	}
 	for attempt := b.S3.AttemptStrategy.Start(); attempt.Next(); {
-		resp, err := b.S3.run(req, nil)
+		resp, err := b.S3.run(hreq, nil)
 
 		if shouldRetry(err) && attempt.HasNext() {
 			continue
@@ -290,7 +292,7 @@ func (b *Bucket) Exists(path string) (exists bool, err error) {
 
 		if err != nil {
 			// We can treat a 403 or 404 as non existance
-			if e, ok := err.(*Error); ok && (e.StatusCode == 403 || e.StatusCode == 404) {
+			if e, ok := err.(*Error); ok && (e.StatusCode == http.StatusForbidden || e.StatusCode == http.StatusNotFound) {
 				return false, nil
 			}
 			return false, err
@@ -313,13 +315,13 @@ func (b *Bucket) Head(path string, headers map[string][]string) (*http.Response,
 		path:    path,
 		headers: headers,
 	}
-	err := b.S3.prepare(req)
+	hreq, err := b.S3.prepare(req)
 	if err != nil {
 		return nil, err
 	}
 
 	for attempt := b.S3.AttemptStrategy.Start(); attempt.Next(); {
-		resp, err := b.S3.run(req, nil)
+		resp, err := b.S3.run(hreq, nil)
 		if shouldRetry(err) && attempt.HasNext() {
 			continue
 		}
@@ -756,11 +758,7 @@ func (b *Bucket) URL(path string) string {
 		bucket: b.Name,
 		path:   path,
 	}
-	err := b.S3.prepare(req)
-	if err != nil {
-		panic(err)
-	}
-	u, err := req.url()
+	u, err := req.url(b.S3.Region)
 	if err != nil {
 		panic(err)
 	}
@@ -776,19 +774,11 @@ func (b *Bucket) SignedURL(path string, expires time.Time) string {
 		path:   path,
 		params: url.Values{"Expires": {strconv.FormatInt(expires.Unix(), 10)}},
 	}
-	err := b.S3.prepare(req)
+	u, err := req.url(b.S3.Region)
 	if err != nil {
 		panic(err)
 	}
-	u, err := req.url()
-	if err != nil {
-		panic(err)
-	}
-	if b.S3.Auth.Token() != "" {
-		return u.String() + "&x-amz-security-token=" + url.QueryEscape(req.headers["X-Amz-Security-Token"][0])
-	} else {
-		return u.String()
-	}
+	return u.String()
 }
 
 // UploadSignedURL returns a signed URL that allows anyone holding the URL
@@ -801,7 +791,6 @@ func (b *Bucket) UploadSignedURL(path, method, content_type string, expires time
 		method = "PUT"
 	}
 	stringToSign := method + "\n\n" + content_type + "\n" + strconv.FormatInt(expire_date, 10) + "\n/" + b.Name + "/" + path
-	fmt.Println("String to sign:\n", stringToSign)
 	a := b.S3.Auth
 	secretKey := a.SecretKey
 	accessId := a.AccessKey
@@ -860,35 +849,82 @@ func (b *Bucket) PostFormArgs(path string, expires time.Time, redirect string) (
 }
 
 type request struct {
-	method   string
-	bucket   string
-	path     string
-	signpath string
-	params   url.Values
-	headers  http.Header
-	baseurl  string
-	payload  io.Reader
-	prepared bool
+	method      string
+	bucket      string
+	path        string
+	params      url.Values
+	headers     http.Header
+	baseurl     string
+	payload     io.Reader
+	preparedURL *url.URL
+	lock        sync.Mutex
 }
 
-func (req *request) url() (*url.URL, error) {
+// url prepares the request, setting the method etc and returning the resulting URL for the given region.
+func (req *request) url(region aws.Region) (*url.URL, error) {
+	req.lock.Lock()
+	defer req.lock.Unlock()
+
+	if req.preparedURL != nil {
+		// Already prepared.
+		return req.preparedURL, nil
+	}
+
+	if err := req.preparePath(region); err != nil {
+		return nil, err
+	}
+
+	if req.method == "" {
+		req.method = "GET"
+	}
+
 	u, err := url.Parse(req.baseurl)
 	if err != nil {
 		return nil, fmt.Errorf("bad S3 endpoint URL %q: %v", req.baseurl, err)
 	}
 	u.RawQuery = req.params.Encode()
 	u.Path = req.path
+	req.preparedURL = u
+
 	return u, nil
+}
+
+// preparePath prepares the requests path for the given region, must be called while holding the lock.
+func (req *request) preparePath(region aws.Region) error {
+	// Ensure the path starts with a /
+	if !strings.HasPrefix(req.path, "/") {
+		req.path = "/" + req.path
+	}
+
+	if req.bucket == "" {
+		// Standard specified URL
+		return nil
+	}
+
+	// Generated a bucket URL
+	if region.S3BucketEndpoint == "" {
+		// Use the path method to address the bucket.
+		req.baseurl = region.S3Endpoint
+		req.path = "/" + req.bucket + req.path
+	} else {
+		// Just in case, prevent injection.
+		if strings.IndexAny(req.bucket, "/:@") >= 0 {
+			return fmt.Errorf("bad S3 bucket: %q", req.bucket)
+		}
+		req.baseurl = strings.Replace(region.S3BucketEndpoint, "${bucket}", req.bucket, -1)
+	}
+
+	return nil
 }
 
 // query prepares and runs the req request.
 // If resp is not nil, the XML data contained in the response
 // body will be unmarshalled on it.
 func (s3 *S3) query(req *request, resp interface{}) error {
-	err := s3.prepare(req)
+	hreq, err := s3.prepare(req)
 	if err == nil {
 		var httpResponse *http.Response
-		httpResponse, err = s3.run(req, resp)
+		httpResponse, err = s3.run(hreq, resp)
 		if resp == nil && httpResponse != nil {
 			httpResponse.Body.Close()
 		}
@@ -897,92 +933,64 @@ func (s3 *S3) query(req *request, resp interface{}) error {
 }
 
 // prepare sets up req to be delivered to S3.
-func (s3 *S3) prepare(req *request) error {
-	var signpath = req.path
-
-	if !req.prepared {
-		req.prepared = true
-		if req.method == "" {
-			req.method = "GET"
-		}
-		// Copy so they can be mutated without affecting on retries.
-		params := make(url.Values)
-		headers := make(http.Header)
-		for k, v := range req.params {
-			params[k] = v
-		}
-		for k, v := range req.headers {
-			headers[k] = v
-		}
-		req.params = params
-		req.headers = headers
-		if !strings.HasPrefix(req.path, "/") {
-			req.path = "/" + req.path
-		}
-		signpath = req.path
-		if req.bucket != "" {
-			req.baseurl = s3.Region.S3BucketEndpoint
-			if req.baseurl == "" {
-				// Use the path method to address the bucket.
-				req.baseurl = s3.Region.S3Endpoint
-				req.path = "/" + req.bucket + req.path
-			} else {
-				// Just in case, prevent injection.
-				if strings.IndexAny(req.bucket, "/:@") >= 0 {
-					return fmt.Errorf("bad S3 bucket: %q", req.bucket)
-				}
-				req.baseurl = strings.Replace(req.baseurl, "${bucket}", req.bucket, -1)
-			}
-			signpath = "/" + req.bucket + signpath
-		}
-	}
-
-	// Always sign again as it's not clear how far the
-	// server has handled a previous attempt.
-	u, err := url.Parse(req.baseurl)
+func (s3 *S3) prepare(req *request) (*http.Request, error) {
+	u, err := req.url(s3.Region)
 	if err != nil {
-		return fmt.Errorf("bad S3 endpoint URL %q: %v", req.baseurl, err)
+		return nil, err
 	}
-	reqSignpathSpaceFix := (&url.URL{Path: signpath}).String()
-	req.headers["Host"] = []string{u.Host}
-	req.headers["Date"] = []string{time.Now().In(time.UTC).Format(time.RFC1123)}
+
+	// Take a copy of the headers to prevent mutation
+	headers := make(http.Header)
+	for k, v := range req.headers {
+		headers[k] = v
+	}
+
+	headers["Host"] = []string{u.Host}
+	headers["Date"] = []string{time.Now().In(time.UTC).Format(time.RFC1123)}
+
 	if s3.Auth.Token() != "" {
-		req.headers["X-Amz-Security-Token"] = []string{s3.Auth.Token()}
+		headers["X-Amz-Security-Token"] = []string{s3.Auth.Token()}
 	}
-	sign(s3.Auth, req.method, reqSignpathSpaceFix, req.params, req.headers)
-	return nil
+
+	hreq := &http.Request{
+		URL:        u,
+		Method:     req.method,
+		Proto:      "HTTP/1.1",
+		ProtoMajor: 1,
+		ProtoMinor: 1,
+		Header:     headers,
+		Host:       u.Host,
+	}
+
+	if debug {
+		dump, _ := httputil.DumpRequest(hreq, true)
+		log.Printf("} -> %s\n", dump)
+	}
+
+	if v, ok := headers["Content-Length"]; ok {
+		hreq.ContentLength, _ = strconv.ParseInt(v[0], 10, 64)
+		delete(headers, "Content-Length")
+	}
+
+	if req.payload != nil {
+		hreq.Body = ioutil.NopCloser(req.payload)
+	}
+
+	if s3.Region.Sign == nil {
+		if err = aws.SignV2(hreq, s3.Auth, "s3"); err != nil {
+			return nil, err
+		}
+	} else if err = s3.Region.Sign(hreq, s3.Auth, "s3"); err != nil {
+		return nil, err
+	}
+
+	return hreq, err
 }
 
 // run sends req and returns the http response from the server.
 // If resp is not nil, the XML data contained in the response
 // body will be unmarshalled on it.
-func (s3 *S3) run(req *request, resp interface{}) (*http.Response, error) {
-	if debug {
-		log.Printf("Running S3 request: %#v", req)
-	}
-
-	u, err := req.url()
-	if err != nil {
-		return nil, err
-	}
-
-	hreq := http.Request{
-		URL:        u,
-		Method:     req.method,
-		ProtoMajor: 1,
-		ProtoMinor: 1,
-		Close:      true,
-		Header:     req.headers,
-	}
-
-	if v, ok := req.headers["Content-Length"]; ok {
-		hreq.ContentLength, _ = strconv.ParseInt(v[0], 10, 64)
-		delete(req.headers, "Content-Length")
-	}
-	if req.payload != nil {
-		hreq.Body = ioutil.NopCloser(req.payload)
-	}
-
+func (s3 *S3) run(req *http.Request, resp interface{}) (*http.Response, error) {
 	if s3.client == nil {
 		s3.client = &http.Client{
 			Transport: &http.Transport{
@@ -1012,7 +1020,8 @@ func (s3 *S3) run(req *request, resp interface{}) (*http.Response, error) {
 		}
 	}
 
-	hresp, err := s3.client.Do(&hreq)
+	hresp, err := s3.client.Do(req)
+
 	if err != nil {
 		return nil, err
 	}
@@ -1020,7 +1029,7 @@ func (s3 *S3) run(req *request, resp interface{}) (*http.Response, error) {
 		dump, _ := httputil.DumpResponse(hresp, true)
 		log.Printf("} -> %s\n", dump)
 	}
-	if hresp.StatusCode != 200 && hresp.StatusCode != 204 && hresp.StatusCode != 206 {
+	if hresp.StatusCode != http.StatusOK && hresp.StatusCode != http.StatusNoContent && hresp.StatusCode != http.StatusPartialContent {
 		defer hresp.Body.Close()
 		return nil, buildError(hresp)
 	}

--- a/s3/s3_test.go
+++ b/s3/s3_test.go
@@ -310,7 +310,11 @@ func (s *S) TestDelMultiObjects(c *C) {
 
 	req := testServer.WaitRequest()
 	c.Assert(req.Method, Equals, "POST")
-	c.Assert(req.URL.RawQuery, Equals, "delete=")
+	vals := req.URL.Query()
+	d, ok := vals["delete"]
+	c.Assert(ok, Equals, true)
+	c.Assert(len(d), Equals, 1)
+	c.Assert(d[0], Equals, "")
 	c.Assert(req.Header["Date"], Not(Equals), "")
 	c.Assert(req.Header["Content-MD5"], Not(Equals), "")
 	c.Assert(req.Header["Content-Type"], Not(Equals), "")

--- a/sqs/sqs.go
+++ b/sqs/sqs.go
@@ -513,10 +513,10 @@ func (s *SQS) query(queueUrl string, params map[string]string, resp interface{})
 		if err != nil {
 			return err
 		}
-		signer := aws.NewV4Signer(s.Auth, "sqs", s.Region)
-		signer.Sign(req)
-		client := http.Client{}
-		r, err = client.Do(req)
+		if err = aws.SignV4(req, s.Auth, "sqs", s.Region.Name); err != nil {
+			return err
+		}
+		r, err = http.DefaultClient.Do(req)
 	} else {
 		sign(s.Auth, "GET", path, params, url_.Host)
 		url_.RawQuery = multimap(params).Encode()
@@ -538,7 +538,7 @@ func (s *SQS) query(queueUrl string, params map[string]string, resp interface{})
 		log.Printf("DUMP:\n", string(dump))
 	}
 
-	if r.StatusCode != 200 {
+	if r.StatusCode != http.StatusOK {
 		return buildError(r)
 	}
 	err = xml.NewDecoder(r.Body).Decode(resp)

--- a/sqs/sqs_test.go
+++ b/sqs/sqs_test.go
@@ -32,7 +32,6 @@ func (s *S) TestCreateQueue(c *C) {
 	c.Assert(req.Method, Equals, "GET")
 	c.Assert(req.URL.Path, Equals, "/")
 	c.Assert(req.Header["Date"], Not(Equals), "")
-	fmt.Printf("%+v\n", req)
 	c.Assert(req.Form["Action"], DeepEquals, []string{"CreateQueue"})
 	c.Assert(req.Form["Attribute.1.Name"], DeepEquals, []string{"VisibilityTimeout"})
 	c.Assert(req.Form["Attribute.1.Value"], DeepEquals, []string{"30"})

--- a/sts/sts.go
+++ b/sts/sts.go
@@ -85,8 +85,9 @@ func (sts *STS) query(params map[string]string, resp interface{}) error {
 		hreq.Header.Set("X-Amz-Security-Token", token)
 	}
 
-	signer := aws.NewV4Signer(sts.Auth, "sts", sts.Region)
-	signer.Sign(hreq)
+	if err = aws.SignV4(hreq, sts.Auth, "sts", sts.Region.Name); err != nil {
+		return err
+	}
 
 	if debug {
 		log.Printf("%v -> {\n", hreq)
@@ -105,7 +106,7 @@ func (sts *STS) query(params map[string]string, resp interface{}) error {
 		log.Printf("response:\n")
 		log.Printf("%v\n}\n", string(dump))
 	}
-	if r.StatusCode != 200 {
+	if r.StatusCode != http.StatusOK {
 		return buildError(r)
 	}
 	err = xml.NewDecoder(r.Body).Decode(resp)


### PR DESCRIPTION
Fully implement AWS4 signing support

This fully implemeents AWS4 signing support, which was only partially added by 5d9165.

This adds the Sign field to Region, which can be used to sign a request with default sign method for that region.

In addition we have a single method that implements signing of requests for each supported signing method:
- SignV2
- SignV4
- SignRoute53

Fix V4Signer adding headers to the request after calculating the canonicalHeaders, due to this change all the tests have had to be updated with corrected checksums and headers.       

Unfortunately it was not possible to make this change 100% backwards compatible.

The following changes are API incompatible and hence may require users to update their code:
- Removes Signature constants, as they are not used any more
- Removes ServiceInfo type, as its not used any more
- Removes Signer interface, as its not compatible with all signing methods.
- Changes the type of Region.RDSEndpoint from ServiceInfo -> string
- Renames Region.CloudWatchServicepoint -> CloudWatchEndpoint and changes its type from ServiceInfo -> string.
- Changes NewService from (auth Auth, serviceInfo ServiceInfo) -> (auth Auth, endpoint string, region Region).
- Changes NewV2Signer from (auth Auth, service ServiceInfo) -> (auth Auth, endpoint string)
- Changes NewCloudWatch from (auth aws.Auth, region aws.ServiceInfo) -> NewCloudWatch(auth aws.Auth, region aws.Region)
- Changes CanonicalRequest return from string to string, error

Also switch to using http status code constants while I'm here to ease comprehension.
