### PR TITLE
Switch s3 to use only AWS Signature Version 4

### DIFF
--- a/s3/sign.go
+++ b/s3/sign.go
@@ -107,7 +107,7 @@ func sign(auth aws.Auth, method, canonicalPath string, params, headers map[strin
 	} else {
 		headers["Authorization"] = []string{"AWS " + auth.AccessKey + ":" + string(signature)}
 	}
-	if debug {
+	if Debug {
 		log.Printf("Signature payload: %q", payload)
 		log.Printf("Signature: %q", signature)
 	}


### PR DESCRIPTION
While s3 states it supports AWS Signature Version 2 this is not the case as it requires custom changes such as Expires parameter, so the previous change which uses the common AWS Signature Version 2 caused failures.

Follow the official AWS SDK in using only Signature Version 4, which is now supported everywhere, to avoid using the old custom s3 Signature Version 2 implementation.

Also expose the option to enable debugging by switching const debug to var Debug.
